### PR TITLE
Fix the AC_DEFINE lines so that autoheader works without warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,7 +193,7 @@ AC_MSG_RESULT($fun_ok)
 
 SC_PATH_TCLCONFIG
 if test x"${no_tcl}" = x ; then
-    AC_DEFINE(HAVE_TCL)
+    AC_DEFINE([HAVE_TCL], [1], [Define if tcl is used.])
 fi
 
 AC_PROG_AWK
@@ -218,7 +218,7 @@ POST="|\& cat"
 case $host_os in
     *cygwin*|*Cygwin* )
         CFLAGS="$CFLAGS -enable-auto-import"
-        AC_DEFINE(HAVE_CYGWIN)
+        AC_DEFINE([HAVE_CYGWIN], [], [Define if the cygwin compiler is used.])
         AC_MSG_RESULT(flagging Cygwin)
 	PRE="sh -c {"
 	POST="}"
@@ -226,7 +226,7 @@ case $host_os in
     *mingw32*|*Mingw32*)
         CFLAGS="$CFLAGS -mconsole -D_WSTRING_DEFINED=1"
 	EXTRA_LIBS="$EXTRA_LIBS -lwsock32"
-        AC_DEFINE(HAVE_MINGW32)
+        AC_DEFINE([HAVE_MINGW32], [], [Define if the mingw32 compiler is used.])
         AC_MSG_RESULT(flagging MinGW)
         ;;
     *osf*|*Osf*)

--- a/filter/configure.ac
+++ b/filter/configure.ac
@@ -150,7 +150,7 @@ PRE=""
 POST="|\& cat"
 case $host_os in
     *cygwin*|*Cygwin* )
-        AC_DEFINE(HAVE_CYGWIN)
+        AC_DEFINE([HAVE_CYGWIN], [], [Define if the cygwin compiler is used.])
         AC_MSG_RESULT(flagging Cygwin)
 	PRE="sh -c {"
 	POST="}"
@@ -158,7 +158,7 @@ case $host_os in
     *mingw32*|*Mingw32*)
         CFLAGS="$CFLAGS -mconsole -D_WSTRING_DEFINED=1"
 	EXTRA_LIBS="$EXTRA_LIBS -lwsock32"
-        AC_DEFINE(HAVE_MINGW32)
+        AC_DEFINE([HAVE_MINGW32], [], [Define if the mingw32 compiler is used.])
         AC_MSG_RESULT(flagging MinGW)
         ;;
     *osf*|*Osf*)

--- a/fitsy/configure.ac
+++ b/fitsy/configure.ac
@@ -121,7 +121,7 @@ PRE=""
 POST="|\& cat"
 case $host_os in
     *cygwin*|*Cygwin* )
-        AC_DEFINE(HAVE_CYGWIN)
+        AC_DEFINE([HAVE_CYGWIN], [], [Define if the cygwin compiler is used.])
         AC_MSG_RESULT(flagging Cygwin)
 	PRE="sh -c {"
 	POST="}"
@@ -129,7 +129,7 @@ case $host_os in
     *mingw32*|*Mingw32*)
         CFLAGS="$CFLAGS -mconsole"
 	EXTRA_LIBS="$EXTRA_LIBS -lwsock32"
-        AC_DEFINE(HAVE_MINGW32)
+        AC_DEFINE([HAVE_MINGW32], [], [Define if the mingw32 compiler is used.])
         AC_MSG_RESULT(flagging MinGW)
         ;;
     *darwin*|*Darwin*)

--- a/util/configure.ac
+++ b/util/configure.ac
@@ -133,7 +133,7 @@ fi
 
 SC_PATH_TCLCONFIG
 if test x"${no_tcl}" = x ; then
-    AC_DEFINE(HAVE_TCL)
+    AC_DEFINE([HAVE_TCL], [1], [Define if tcl is used.])
 fi
 
 AC_MSG_CHECKING(for external zlib)
@@ -146,7 +146,7 @@ PRE=""
 POST="|\& cat"
 case $host_os in
     *cygwin*|*Cygwin* )
-        AC_DEFINE(HAVE_CYGWIN)
+        AC_DEFINE([HAVE_CYGWIN], [], [Define if the cygwin compiler is used.])
         AC_MSG_RESULT(flagging Cygwin)
 	PRE="sh -c {"
 	POST="}"
@@ -154,7 +154,7 @@ case $host_os in
     *mingw32*|*Mingw32*)
         CFLAGS="$CFLAGS -mconsole -D_WSTRING_DEFINED=1"
 	EXTRA_LIBS="$EXTRA_LIBS -lwsock32"
-        AC_DEFINE(HAVE_MINGW32)
+        AC_DEFINE([HAVE_MINGW32], [], [Define if the mingw32 compiler is used.])
         AC_MSG_RESULT(flagging MinGW)
         ;;
     *osf*|*Osf*)

--- a/wcs/configure.ac
+++ b/wcs/configure.ac
@@ -125,7 +125,7 @@ PRE=""
 POST="|\& cat"
 case $host_os in
     *cygwin*|*Cygwin* )
-        AC_DEFINE(HAVE_CYGWIN)
+        AC_DEFINE([HAVE_CYGWIN], [], [Define if the cygwin compiler is used.])
         AC_MSG_RESULT(flagging Cygwin)
 	PRE="sh -c {"
 	POST="}"
@@ -133,7 +133,7 @@ case $host_os in
     *mingw32*|*Mingw32*)
         CFLAGS="$CFLAGS -mconsole -D_WSTRING_DEFINED=1"
 	EXTRA_LIBS="$EXTRA_LIBS -lwsock32"
-        AC_DEFINE(HAVE_MINGW32)
+        AC_DEFINE([HAVE_MINGW32], [], [Define if the mingw32 compiler is used.])
         AC_MSG_RESULT(flagging MinGW)
         ;;
     *osf*|*Osf*)


### PR DESCRIPTION
Otherwise, one gets warnings like

```
autoheader: warning: missing template HAVE_CYGWIN
```
