### PR TITLE
 Fix several manpage problems

### DIFF
--- a/man/man1/funcalc.1
+++ b/man/man1/funcalc.1
@@ -131,20 +131,20 @@
 .IX Title "funcalc 1"
 .TH funcalc 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfuncalc \- Funtools calculator (for binary tables)\fR
+funcalc \- Funtools calculator (for binary tables)
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funcalc [\-n] [\-a argstr] [\-e expr] [\-f file] [\-l link] [\-p prog] <iname> [oname [columns]]
+\&\fBfuncalc\fR [\-n] [\-a argstr] [\-e expr] [\-f file] [\-l link] [\-p prog] <iname> [oname [columns]]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 7
-\&  -a argstr    # user arguments to pass to the compiled program
-\&  -e expr      # funcalc expression
-\&  -f file      # file containing funcalc expression
-\&  -l libs      # libs to add to link command  
-\&  -n           # output generated code instead of compiling and executing
-\&  -p prog      # generate named program, no execution
-\&  -u           # die if any variable is undeclared (don't auto-declare)
+\&  \-a argstr    # user arguments to pass to the compiled program
+\&  \-e expr      # funcalc expression
+\&  \-f file      # file containing funcalc expression
+\&  \-l libs      # libs to add to link command
+\&  \-n           # output generated code instead of compiling and executing
+\&  \-p prog      # generate named program, no execution
+\&  \-u           # die if any variable is undeclared (don't auto-declare)
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -203,7 +203,7 @@ or:
 When this expression is executed using a command such as:
 .PP
 .Vb 1
-\&  funcalc -f swap.expr itest.ev otest.ev
+\&  funcalc \-f swap.expr itest.ev otest.ev
 .Ve
 .PP
 the resulting file will have values of the x and y columns swapped.
@@ -225,19 +225,19 @@ columns using \s-1TFORM:\s0
 .IP "\(bu" 4
 A: \s-1ASCII\s0 characters
 .IP "\(bu" 4
-B: unsigned 8\-bit char
+B: unsigned 8-bit char
 .IP "\(bu" 4
-I: signed 16\-bit int
+I: signed 16-bit int
 .IP "\(bu" 4
-U: unsigned 16\-bit int (not standard \s-1FITS\s0)
+U: unsigned 16-bit int (not standard \s-1FITS\s0)
 .IP "\(bu" 4
-J: signed 32\-bit int
+J: signed 32-bit int
 .IP "\(bu" 4
-V: unsigned 32\-bit int (not standard \s-1FITS\s0)
+V: unsigned 32-bit int (not standard \s-1FITS\s0)
 .IP "\(bu" 4
-E: 32\-bit float
+E: 32-bit float
 .IP "\(bu" 4
-D: 64\-bit float
+D: 64-bit float
 .IP "\(bu" 4
 X: bits (treated as an array of chars)
 .PP
@@ -313,14 +313,14 @@ column array:
 .PP
 The 'X' (bits) data type is treated as a char array of dimension
 (numeric_count/8), i.e., 16X is processed as a 2\-byte char array. Each
-8\-bit array element is accessed separately:
+8-bit array element is accessed separately:
 .PP
 .Vb 2
 \&  cur->stat[0]:16X  = 1;
 \&  cur->stat[1]      = 2;
 .Ve
 .PP
-Here, a 16\-bit column is created with the \s-1MSB\s0 is set to 1 and the \s-1LSB\s0 set to 2.
+Here, a 16-bit column is created with the \s-1MSB\s0 is set to 1 and the \s-1LSB\s0 set to 2.
 .PP
 By default, all processed rows are written to the specified output
 file. If you want to skip writing certain rows, simply execute the C
@@ -433,7 +433,7 @@ example, assuming that \fIinit()\fR and \fIfinish()\fR are in the library
 libmysubs.a in the /opt/special/lib directory, use:
 .PP
 .Vb 1
-\&  funcalc  -l "-L/opt/special/lib -lmysubs" ...
+\&  funcalc  \-l "\-L/opt/special/lib \-lmysubs" ...
 .Ve
 .PP
 User arguments can be passed to a compiled funcalc program using a string
@@ -441,7 +441,7 @@ argument to the \*(L"\-a\*(R" switch.  The string should contain all of the
 user arguments. For example, to pass the integers 1 and 2, use:
 .PP
 .Vb 1
-\&  funcalc -a "1 2" ...
+\&  funcalc \-a "1 2" ...
 .Ve
 .PP
 The arguments are stored in an internal array and are accessed as
@@ -470,7 +470,7 @@ This expression will print out x, y, and pha values for all rows in which
 the pha value is between the two user-input values:
 .PP
 .Vb 6
-\&  funcalc -a '1 12' -f foo snr.ev'[cir 512 512 .1]'
+\&  funcalc \-a '1 12' \-f foo snr.ev'[cir 512 512 .1]'
 \&  512 512 6
 \&  512 512 8
 \&  512 512 5
@@ -479,7 +479,7 @@ the pha value is between the two user-input values:
 .Ve
 .PP
 .Vb 4
-\&  funcalc -a '5 6' -f foo snr.ev'[cir 512 512 .1]'
+\&  funcalc \-a '5 6' \-f foo snr.ev'[cir 512 512 .1]'
 \&  512 512 6
 \&  512 512 5
 \&  512 512 5
@@ -619,4 +619,4 @@ adding support for image expressions at a later point, if there is
 demand for such support from the community.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funcen.1
+++ b/man/man1/funcen.1
@@ -131,17 +131,17 @@
 .IX Title "funcen 1"
 .TH funcen 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfuncen \- find centroid (for binary tables)\fR
+funcen \- find centroid (for binary tables)
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funcen [\-i] [\-n iter] [\-t tol] [\-v lev] <iname> <region>
+\&\fBfuncen\fR [\-i] [\-n iter] [\-t tol] [\-v lev] <iname> <region>
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 4
-\&  -i            # use image filtering (default: event filtering)
-\&  -n iter       # max number of iterations (default: 0)
-\&  -t tol        # pixel tolerance distance (default: 1.0)
-\&  -v [0,1,2,3]  # output verbosity level (default: 0)
+\&  \-i            # use image filtering (default: event filtering)
+\&  \-n iter       # max number of iterations (default: 0)
+\&  \-t tol        # pixel tolerance distance (default: 1.0)
+\&  \-v [0,1,2,3]  # output verbosity level (default: 0)
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -190,12 +190,12 @@ The last 3 \s-1WCS\s0 values are output if \s-1WCS\s0 information is available i
 data file header. Thus, for example:
 .PP
 .Vb 2
-\&  [sh] funcen -n 0 snr.ev "cir 505 508 5"
+\&  [sh] funcen \-n 0 snr.ev "cir 505 508 5"
 \&  915 505.00 508.00 345.284038 58.870920 j2000
 .Ve
 .PP
 .Vb 2
-\&  [sh] funcen -n 3 snr.ev "cir 505 508 5"
+\&  [sh] funcen \-n 3 snr.ev "cir 505 508 5"
 \&  1120 504.43 509.65 345.286480 58.874587 j2000
 .Ve
 .PP
@@ -208,7 +208,7 @@ level 1, the output essentially contains the same information as level
 0, but with keyword formatting:
 .PP
 .Vb 5
-\&  [sh] funcen -v 1 -n 3 snr.ev "cir 505 508 5"
+\&  [sh] funcen \-v 1 \-n 3 snr.ev "cir 505 508 5"
 \&  event_file:     snr.ev
 \&  initial_region: cir 505 508 5
 \&  tolerance:      1.0000
@@ -239,7 +239,7 @@ give different results because of how boundary events are processed:
 .Ve
 .PP
 .Vb 2
-\&  [sh] funcen -i snr.ev "cir 505 508 5"
+\&  [sh] funcen \-i snr.ev "cir 505 508 5"
 \&  798 505.00 508.00 345.284038 58.870920 j2000
 .Ve
 .PP
@@ -247,4 +247,4 @@ See Region Boundaries for more information
 about how boundaries are calculated using these two methods.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funcnts.1
+++ b/man/man1/funcnts.1
@@ -131,29 +131,29 @@
 .IX Title "funcnts 1"
 .TH funcnts 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfuncnts \- count photons in specified regions, with bkgd subtraction\fR
+funcnts \- count photons in specified regions, with bkgd subtraction
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funcnts  [switches] <source_file> [source_region] [bkgd_file] [bkgd_region|bkgd_value]
+\&\fBfuncnts\fR  [switches] <source_file> [source_region] [bkgd_file] [bkgd_region|bkgd_value]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 16
-\&  -e "source_exposure[;bkgd_exposure]"
+\&  \-e "source_exposure[;bkgd_exposure]"
 \&                # source (bkgd) FITS exposure image using matching files
-\&  -w "source_exposure[;bkgd_exposure]"
+\&  \-w "source_exposure[;bkgd_exposure]"
 \&                # source (bkgd) FITS exposure image using WCS transform
-\&  -t "source_timecorr[;bkgd_timecorr]"
+\&  \-t "source_timecorr[;bkgd_timecorr]"
 \&                # source (bkgd) time correction value or header parameter name
-\&  -g            # output using nice g format
-\&  -G            # output using %.14g format (maximum precision)
-\&  -i "[column;]int1;int2..." # column-based intervals
-\&  -m            # match individual source and bkgd regions
-\&  -p            # output in pixels, even if wcs is present
-\&  -r            # output inner/outer radii (and angles) for annuli (and pandas)
-\&  -s            # output summed values
-\&  -v "scol[;bcol]" # src and bkgd value columns for tables
-\&  -T            # output in starbase/rdb format
-\&  -z            # output regions with zero area
+\&  \-g            # output using nice g format
+\&  \-G            # output using %.14g format (maximum precision)
+\&  \-i "[column;]int1;int2..." # column-based intervals
+\&  \-m            # match individual source and bkgd regions
+\&  \-p            # output in pixels, even if wcs is present
+\&  \-r            # output inner/outer radii (and angles) for annuli (and pandas)
+\&  \-s            # output summed values
+\&  \-v "scol[;bcol]" # src and bkgd value columns for tables
+\&  \-T            # output in starbase/rdb format
+\&  \-z            # output regions with zero area
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -280,7 +280,7 @@ for further analysis:
 .Ve
 .PP
 .Vb 2
-\&  [sh] sed -f funcnts.sed funcnts.out
+\&  [sh] sed \-f funcnts.sed funcnts.out
 \&  1     3826.403    66.465      555.597     5.972  96831.98     0.040     0.001
 .Ve
 .PP
@@ -362,7 +362,7 @@ Using the \fB\-m\fR switch causes \fBfuncnts\fR to use each of the two
 background regions independently with each of the two source regions:
 .PP
 .Vb 10
-\&  [sh] funcnts -m snr.ev "annulus(502,512,0,22,n=2)" "ann(502,512,50,100,n=2)"
+\&  [sh] funcnts \-m snr.ev "annulus(502,512,0,22,n=2)" "ann(502,512,50,100,n=2)"
 \&  # source
 \&  #   data file:        snr.ev
 \&  #   degrees/pix:      0.00222222
@@ -422,7 +422,7 @@ angles) for each separate region. The \fB\-r\fR switch will add radii
 and angle columns to the output table:
 .PP
 .Vb 12
-\&  [sh] funcnts -r snr.ev "annulus(502,512,0,22,n=2)" "ann(502,512,50,100,n=2)"
+\&  [sh] funcnts \-r snr.ev "annulus(502,512,0,22,n=2)" "ann(502,512,50,100,n=2)"
 \&  # source
 \&  #   data file:        snr.ev
 \&  #   degrees/pix:      0.00222222
@@ -518,7 +518,7 @@ above). A simplified version of this script is shown below:
 \&        exit
 \&      }
 \&    }
-\&    ' | gnuplot -persist - 1>/dev/null 2>&1
+\&    ' | gnuplot \-persist - 1>/dev/null 2>&1
 .Ve
 .PP
 .Vb 34
@@ -553,7 +553,7 @@ above). A simplified version of this script is shown below:
 \&    }
 \&    '
 \&  else
-\&    echo "funcnts -r ... | funcnts.plot [ds9|gnuplot]"
+\&    echo "funcnts \-r ... | funcnts.plot [ds9|gnuplot]"
 \&    exit 1
 \&  fi
 .Ve
@@ -562,7 +562,7 @@ Thus, to run \fBfuncnts\fR and plot the results using gnuplot (version 3.7
 or above), use:
 .PP
 .Vb 1
-\&  funcnts -r snr.ev "annulus(502,512,0,50,n=5)" ...  | funcnts.plot gnuplot
+\&  funcnts \-r snr.ev "annulus(502,512,0,50,n=5)" ...  | funcnts.plot gnuplot
 .Ve
 .PP
 The \fB\-s\fR (sum) switch causes \fBfuncnts\fR to produce an
@@ -570,7 +570,7 @@ additional table of summed (integrated) background subtracted values,
 along with the default table of individual values:
 .PP
 .Vb 10
-\&  [sh] funcnts -s snr.ev "annulus(502,512,0,50,n=5)" "annulus(502,512,50,100)"
+\&  [sh] funcnts \-s snr.ev "annulus(502,512,0,50,n=5)" "annulus(502,512,50,100)"
 \&  # source
 \&  #   data file:        snr.ev
 \&  #   degrees/pix:      0.00222222
@@ -701,8 +701,8 @@ either be a numeric constant or the name of a header parameter in
 the source (or background) file:
 .PP
 .Vb 2
-\&  [sh] funcnts -t 23.4 ...            # number for source
-\&  [sh] funcnts -t "LIVETIME;23.4" ... # param for source, numeric for bkgd
+\&  [sh] funcnts \-t 23.4 ...            # number for source
+\&  [sh] funcnts \-t "LIVETIME;23.4" ... # param for source, numeric for bkgd
 .Ve
 .PP
 When a time correction is specified, it is applied to the net counts
@@ -724,7 +724,7 @@ Two formats are supported for interval specification. The most general
 format is semi-colon-delimited list of filters to be used as intervals:
 .PP
 .Vb 1
-\&  funcnts -i "pha=1:5;pha=6:10;pha=11:15" snr.ev "circle(502,512,22)" ...
+\&  funcnts \-i "pha=1:5;pha=6:10;pha=11:15" snr.ev "circle(502,512,22)" ...
 .Ve
 .PP
 Conceptually, this will be equivalent to running \fBfuncnts\fR three times:
@@ -741,7 +741,7 @@ the data.
 Note that complex filters can be used to specify intervals:
 .PP
 .Vb 1
-\&  funcnts -i "pha=1:5&&pi=4;pha=6:10&&pi=5;pha=11:15&&pi=6" snr.ev ...
+\&  funcnts \-i "pha=1:5&&pi=4;pha=6:10&&pi=5;pha=11:15&&pi=6" snr.ev ...
 .Ve
 .PP
 The program simply runs the data through each filter in turn and generates
@@ -752,7 +752,7 @@ the specified filters do not have to be intervals at all. Nor does one
 \&\*(L"interval\*(R" filter have to be related to another. For example:
 .PP
 .Vb 1
-\&  funcnts -i "pha=1:5;pi=6:10;energy=11:15" snr.ev "circle(502,512,22)" ...
+\&  funcnts \-i "pha=1:5;pi=6:10;energy=11:15" snr.ev "circle(502,512,22)" ...
 .Ve
 .PP
 is equivalent to running \fBfuncnts\fR three times with unrelated filter
@@ -764,7 +764,7 @@ that column. In this format, a column name is specified first,
 followed by intervals:
 .PP
 .Vb 1
-\&  funcnts -i "pha;1:5;6:10;11:15" snr.ev "circle(502,512,22)" ...
+\&  funcnts \-i "pha;1:5;6:10;11:15" snr.ev "circle(502,512,22)" ...
 .Ve
 .PP
 This is equivalent to the first example, but requires less typing. The
@@ -803,4 +803,4 @@ For more information about these difference, see the discussion of
 Region Boundaries.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funcone.1
+++ b/man/man1/funcone.1
@@ -118,8 +118,8 @@
 .    ds : e
 .    ds 8 ss
 .    ds o a
-.    ds d- d\h'-1'\(ga
-.    ds D- D\h'-1'\(hy
+.    ds d- d\h'\-1'\(ga
+.    ds D- D\h'\-1'\(hy
 .    ds th \o'bp'
 .    ds Th \o'LP'
 .    ds ae ae
@@ -131,22 +131,22 @@
 .IX Title "funcone 1"
 .TH funcone 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfuncone \- cone search of a binary table containing RA, Dec columns\fR
+funcone \- cone search of a binary table containing RA, Dec columns
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funcone <switches>  <iname> <oname> <ra[hdr]> <dec[hdr]> <radius[dr'"]> [columns]
+\&\fBfuncone\fR <switches>  <iname> <oname> <ra[hdr]> <dec[hdr]> <radius[dr'"]> [columns]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 9
-\&  -d deccol:[hdr]  # Dec column name, units (def: DEC:d)
-\&  -j               # join columns from list file
-\&  -J               # join columns from list file, output all rows
-\&  -l listfile      # read centers and radii from a list
-\&  -L listfile      # read centers and radii from a list, output list rows
-\&  -n               # don't use cone limits as a filter
-\&  -r  racol:[hdr]  # RA column name, units (def: RA:h)
-\&  -x               # append RA_CEN, DEC_CEN, RAD_CEN, CONE_KEY cols
-\&  -X               # append RA_CEN, DEC_CEN, RAD_CEN, CONE_KEY cols, output all rows
+\&  \-d deccol:[hdr]  # Dec column name, units (def: DEC:d)
+\&  \-j               # join columns from list file
+\&  \-J               # join columns from list file, output all rows
+\&  \-l listfile      # read centers and radii from a list
+\&  \-L listfile      # read centers and radii from a list, output list rows
+\&  \-n               # don't use cone limits as a filter
+\&  \-r  racol:[hdr]  # RA column name, units (def: RA:h)
+\&  \-x               # append RA_CEN, DEC_CEN, RAD_CEN, CONE_KEY cols
+\&  \-X               # append RA_CEN, DEC_CEN, RAD_CEN, CONE_KEY cols, output all rows
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -270,7 +270,7 @@ To get \s-1RA\s0 and Dec from a list but use a static value for radius (and
 also write identifying info for each row in the list):
 .PP
 .Vb 1
-\&  funcone -x -l list.txt in.fits out.fits MYRA MYDec 0.01
+\&  funcone \-x \-l list.txt in.fits out.fits MYRA MYDec 0.01
 .Ve
 .PP
 User specified columns in degrees, \s-1RA\s0 position in hours (sexagesimal
@@ -278,8 +278,8 @@ notation), Dec position in degrees (sexagesimal notation) and radius
 in arc minutes:
 .PP
 .Vb 1
-\&  funcone -r myRa:d -d myDec in.fits out.fits 12:30:15.5 30:12 15'
+\&  funcone \-r myRa:d \-d myDec in.fits out.fits 12:30:15.5 30:12 15'
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/fundisp.1
+++ b/man/man1/fundisp.1
@@ -131,18 +131,18 @@
 .IX Title "fundisp 1"
 .TH fundisp 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfundisp \- display data in a Funtools data file\fR
+fundisp \- display data in a Funtools data file
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-fundisp  [\-f format] [\-l] [\-n] [\-T] <iname> [columns|bitpix=n]
+\&\fBfundisp\fR  [\-f format] [\-l] [\-n] [\-T] <iname> [columns|bitpix=n]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 5
-\&  -f      # format string for display
-\&  -l      # display image as a list containing the columns X, Y, VAL
-\&  -n      # don't output header
-\&  -F [c]  # use specified character as column separator (def: space)
-\&  -T      # output in rdb/starbase format (tab separators)
+\&  \-f      # format string for display
+\&  \-l      # display image as a list containing the columns X, Y, VAL
+\&  \-n      # don't output header
+\&  \-F [c]  # use specified character as column separator (def: space)
+\&  \-T      # output in rdb/starbase format (tab separators)
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -189,15 +189,15 @@ argument can be used to specify the columns to display.  For example:
 \&  [sh] fundisp "test.ev[time-(int)time>=.99]" "x y time"
 \&          X        Y                  TIME
 \&   -------- -------- ---------------------
-\&          5       -6           40.99000000
-\&          4       -5           59.99000000
-\&         -1        0          154.99000000
-\&         -2        1          168.99000000
-\&         -3        2          183.99000000
-\&         -4        3          199.99000000
-\&         -5        4          216.99000000
-\&         -6        5          234.99000000
-\&         -7        6          253.99000000
+\&          5       \-6           40.99000000
+\&          4       \-5           59.99000000
+\&         \-1        0          154.99000000
+\&         \-2        1          168.99000000
+\&         \-3        2          183.99000000
+\&         \-4        3          199.99000000
+\&         \-5        4          216.99000000
+\&         \-6        5          234.99000000
+\&         \-7        6          253.99000000
 .Ve
 .PP
 The special column \fB$REGION\fR can be specified to display the
@@ -207,15 +207,15 @@ region id of each row:
 \&  [sh $] fundisp "test.ev[time-(int)time>=.99&&annulus(0 0 0 10 n=3)]" 'x y time $REGION'
 \&          X        Y                  TIME     REGION
 \&   -------- -------- --------------------- ----------
-\&          5       -6           40.99000000          3
-\&          4       -5           59.99000000          2
-\&         -1        0          154.99000000          1
-\&         -2        1          168.99000000          1
-\&         -3        2          183.99000000          2
-\&         -4        3          199.99000000          2
-\&         -5        4          216.99000000          2
-\&         -6        5          234.99000000          3
-\&         -7        6          253.99000000          3
+\&          5       \-6           40.99000000          3
+\&          4       \-5           59.99000000          2
+\&         \-1        0          154.99000000          1
+\&         \-2        1          168.99000000          1
+\&         \-3        2          183.99000000          2
+\&         \-4        3          199.99000000          2
+\&         \-5        4          216.99000000          2
+\&         \-6        5          234.99000000          3
+\&         \-7        6          253.99000000          3
 .Ve
 .PP
 Here only rows with the proper fractional time and whose position also is
@@ -225,18 +225,18 @@ Columns can be excluded from display using a minus sign before the
 column:
 .PP
 .Vb 12
-\&  [sh $] fundisp "test.ev[time-(int)time>=.99]" "-time"
+\&  [sh $] fundisp "test.ev[time-(int)time>=.99]" "\-time"
 \&          X        Y      PHA         PI          DX          DY
 \&   -------- -------- -------- ---------- ----------- -----------
-\&          5       -6        5         -6        5.50       -6.50
-\&          4       -5        4         -5        4.50       -5.50
-\&         -1        0       -1          0       -1.50        0.50
-\&         -2        1       -2          1       -2.50        1.50
-\&         -3        2       -3          2       -3.50        2.50
-\&         -4        3       -4          3       -4.50        3.50
-\&         -5        4       -5          4       -5.50        4.50
-\&         -6        5       -6          5       -6.50        5.50
-\&         -7        6       -7          6       -7.50        6.50
+\&          5       \-6        5         \-6        5.50       \-6.50
+\&          4       \-5        4         \-5        4.50       \-5.50
+\&         \-1        0       \-1          0       \-1.50        0.50
+\&         \-2        1       \-2          1       \-2.50        1.50
+\&         \-3        2       \-3          2       \-3.50        2.50
+\&         \-4        3       \-4          3       \-4.50        3.50
+\&         \-5        4       \-5          4       \-5.50        4.50
+\&         \-6        5       \-6          5       \-6.50        5.50
+\&         \-7        6       \-7          6       \-7.50        6.50
 .Ve
 .PP
 All columns except the time column are displayed.
@@ -245,18 +245,18 @@ The special column \fB$N\fR can be specified to display the
 ordinal value of each row. Thus, continuing the previous example:
 .PP
 .Vb 12
-\&  fundisp "test.ev[time-(int)time>=.99]" '-time $n'
+\&  fundisp "test.ev[time-(int)time>=.99]" '\-time $n'
 \&         X        Y      PHA         PI          DX          DY          N
 \&   ------- -------- -------- ---------- ----------- ----------- ----------
-\&         5       -6        5         -6        5.50       -6.50        337
-\&         4       -5        4         -5        4.50       -5.50        356
-\&        -1        0       -1          0       -1.50        0.50        451
-\&        -2        1       -2          1       -2.50        1.50        465
-\&        -3        2       -3          2       -3.50        2.50        480
-\&        -4        3       -4          3       -4.50        3.50        496
-\&        -5        4       -5          4       -5.50        4.50        513
-\&        -6        5       -6          5       -6.50        5.50        531
-\&        -7        6       -7          6       -7.50        6.50        550
+\&         5       \-6        5         \-6        5.50       \-6.50        337
+\&         4       \-5        4         \-5        4.50       \-5.50        356
+\&        \-1        0       \-1          0       \-1.50        0.50        451
+\&        \-2        1       \-2          1       \-2.50        1.50        465
+\&        \-3        2       \-3          2       \-3.50        2.50        480
+\&        \-4        3       \-4          3       \-4.50        3.50        496
+\&        \-5        4       \-5          4       \-5.50        4.50        513
+\&        \-6        5       \-6          5       \-6.50        5.50        531
+\&        \-7        6       \-7          6       \-7.50        6.50        550
 .Ve
 .PP
 Note that the column specification is enclosed in single quotes to protect
@@ -335,7 +335,7 @@ If the \fB\-l\fR (list) switch is used, then an image is displayed as a
 list containing the columns: X, Y, \s-1VAL\s0. For example:
 .PP
 .Vb 33
-\&  fundisp -l "test1.fits[2:6,2:7]" bitpix=-32
+\&  fundisp \-l "test1.fits[2:6,2:7]" bitpix=-32
 \&            X          Y         VAL
 \&   ---------- ---------- -----------
 \&            2          2        6.00
@@ -413,7 +413,7 @@ having that data type). For example, you can change the double and
 short formats for all columns like this:
 .PP
 .Vb 1
-\&  [sh] fundisp -f "D=%22.11f I=%3d" snr.ev "time x y"
+\&  [sh] fundisp \-f "D=%22.11f I=%3d" snr.ev "time x y"
 .Ve
 .PP
 .Vb 5
@@ -427,7 +427,7 @@ short formats for all columns like this:
 Alternatively, you can change the format of the time and x columns like this:
 .PP
 .Vb 1
-\&  [sh] fundisp -f "time=%22.11f x=%3d" snr.ev "time x y"
+\&  [sh] fundisp \-f "time=%22.11f x=%3d" snr.ev "time x y"
 .Ve
 .PP
 .Vb 5
@@ -449,7 +449,7 @@ column name.  This means that, in the examples above, \*(L"X=%3d\*(R" will refer
 to the X (bit) datatype, while \*(L"x=%3d\*(R" will refer to the X column:
 .PP
 .Vb 1
-\&  [sh] fundisp -f "X=%3d" snr.ev "x y"
+\&  [sh] fundisp \-f "X=%3d" snr.ev "x y"
 .Ve
 .PP
 .Vb 5
@@ -461,7 +461,7 @@ to the X (bit) datatype, while \*(L"x=%3d\*(R" will refer to the X column:
 .Ve
 .PP
 .Vb 1
-\&  [sh] fundisp -f "x=%3d" snr.ev "x y"
+\&  [sh] fundisp \-f "x=%3d" snr.ev "x y"
 .Ve
 .PP
 .Vb 5
@@ -509,7 +509,7 @@ list. Note that you must supply a minimum field width, i.e., \*(L"%6d\*(R" and
 By using \-f [format], you can change the double and short formats like this:
 .PP
 .Vb 1
-\&  [sh] fundisp -f "22.11f - - 3d" snr.ev "time x y"
+\&  [sh] fundisp \-f "22.11f - - 3d" snr.ev "time x y"
 .Ve
 .PP
 .Vb 5
@@ -530,7 +530,6 @@ such as sed, at the cost of generating unaligned columns. For example:
 .PP
 fundisp \-F',' snr.ev'[cir 512 512 .1]'
        X,       Y,     \s-1PHA\s0,      \s-1PI\s0,                 \s-1TIME\s0,      \s-1DX\s0,      \s-1DY\s0
-\&\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-
      512,     512,       6,       7,    79493997.45854475,     578,     574
      512,     512,       8,       9,    79494575.58943175,     579,     573
      512,     512,       5,       6,    79493631.03866175,     578,     575
@@ -539,7 +538,6 @@ fundisp \-F',' snr.ev'[cir 512 512 .1]'
 .PP
 fundisp \-F',' snr.ev'[cir 512 512 .1]' | sed 's/ *, */,/g'
        X,Y,PHA,PI,TIME,DX,DY
-\&\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-,\-\-\-\-\-\-\-\-
      512,512,6,7,79493997.45854475,578,574
      512,512,8,9,79494575.58943175,579,573
      512,512,5,6,79493631.03866175,578,575
@@ -588,4 +586,4 @@ The resulting filter file can then be used in various funtools programs:
 to process only the events in the good-time intervals.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funhead.1
+++ b/man/man1/funhead.1
@@ -131,17 +131,17 @@
 .IX Title "funhead 1"
 .TH funhead 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfunhead \- display a header in a Funtools file\fR
+funhead \- display a header in a Funtools file
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funhead  [\-a] [\-s] [\-t] [\-L] <iname> [oname ename]
+\&\fBfunhead\fR  [\-a] [\-s] [\-t] [\-L] <iname> [oname ename]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 4
-\&  -a    # display all extension headers
-\&  -s    # display 79 chars instead of 80 before the new-line
-\&  -t    # prepend data type char to each line of output
-\&  -L    # output in rdb/starbase list format
+\&  \-a    # display all extension headers
+\&  \-s    # display 79 chars instead of 80 before the new-line
+\&  \-t    # prepend data type char to each line of output
+\&  \-L    # output in rdb/starbase list format
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -267,15 +267,15 @@ modifies and deletes existing parameters:
 \&  # add foo2
 \&  FOO2 = 200
 \&  # reset foo1 to a different value
-\&  FOO1 -1
+\&  FOO1 \-1
 \&  # delete foo2
-\&  -FOO2
+\&  \-FOO2
 \&  # change existing value
 \&  EXTVER 2
 \&  ? XS-SORT
 \&  XS-SORT = 'EOF     '            /  type of event sort
 \&  # delete existing value
-\&  -XS-SORT
+\&  \-XS-SORT
 \&  # exit
 \&  ^D
 .Ve
@@ -284,4 +284,4 @@ See Column-based Text Files
 for more information about header parameter format.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funhist.1
+++ b/man/man1/funhist.1
@@ -131,16 +131,16 @@
 .IX Title "funhist 1"
 .TH funhist 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfunhist \- create a 1D histogram of a column (from a FITS binary table or raw event file) or an image\fR
+funhist \- create a 1D histogram of a column (from a FITS binary table or raw event file) or an image
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funhist  [\-n|\-w|\-T] <iname> [column] [[lo:hi:]bins]
+\&\fBfunhist\fR  [\-n|\-w|\-T] <iname> [column] [[lo:hi:]bins]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 3
-\&  -n    # normalize bin value by the width of each bin
-\&  -w    # specify bin width instead of number of bins in arg3
-\&  -T    # output in rdb/starbase format (tab separators)
+\&  \-n    # normalize bin value by the width of each bin
+\&  \-w    # specify bin width instead of number of bins in arg3
+\&  \-T    # output in rdb/starbase format (tab separators)
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -193,7 +193,7 @@ to specify the width of each bin rather than the number of bins. Thus:
 means that 5 bins of width 20 are used in the histogram, while:
 .PP
 .Vb 1
-\&  funhist -w test.ev pha 1:100:5
+\&  funhist \-w test.ev pha 1:100:5
 .Ve
 .PP
 means that 20 bins of width 5 are used in the histogram.
@@ -209,20 +209,20 @@ can be processed thus:
 \&  [sh] funhist test.ev pha
 \&  # data file:        /home/eric/data/test.ev
 \&  # column:           pha
-\&  # min,max,bins:     -7.5 7.5 15
+\&  # min,max,bins:     \-7.5 7.5 15
 .Ve
 .PP
 .Vb 17
 \&     bin     value               lo_edge               hi_edge
 \&  ------ --------- --------------------- ---------------------
-\&       1        22           -7.50000000           -6.50000000
-\&       2        21           -6.50000000           -5.50000000
-\&       3        20           -5.50000000           -4.50000000
-\&       4        19           -4.50000000           -3.50000000
-\&       5        18           -3.50000000           -2.50000000
-\&       6        17           -2.50000000           -1.50000000
-\&       7        16           -1.50000000           -0.50000000
-\&       8        30           -0.50000000            0.50000000
+\&       1        22           \-7.50000000           \-6.50000000
+\&       2        21           \-6.50000000           \-5.50000000
+\&       3        20           \-5.50000000           \-4.50000000
+\&       4        19           \-4.50000000           \-3.50000000
+\&       5        18           \-3.50000000           \-2.50000000
+\&       6        17           \-2.50000000           \-1.50000000
+\&       7        16           \-1.50000000           \-0.50000000
+\&       8        30           \-0.50000000            0.50000000
 \&       9        16            0.50000000            1.50000000
 \&      10        17            1.50000000            2.50000000
 \&      11        18            2.50000000            3.50000000
@@ -269,7 +269,7 @@ For a table histogram, the \fB\-n\fR(normalize) switch can be used to
 normalize the bin value by the width of the bin (i.e., hi_edge\-lo_edge):
 .PP
 .Vb 5
-\&  [sh] funhist -n test.ev pha 1:6:3 
+\&  [sh] funhist \-n test.ev pha 1:6:3 
 \&  # data file:          test.ev
 \&  # column:             pha
 \&  # min,max,bins:       0.5 6.5 3
@@ -352,12 +352,12 @@ results, using a script such as:
 .PP
 .Vb 7
 \&  #!/bin/sh
-\&  sed -e '1,/---- .*/d
+\&  sed \-e '1,/---- .*/d
 \&  /^$/,$d' | \e
 \&  awk '\e
 \&  BEGIN{print "set nokey; set title \e"funhist\e"; set xlabel \e"bin\e"; set ylabel \e"counts\e"; plot \e"-\e" with boxes"}   \e
 \&  {print $3, $2, $4-$3}'        | \e
-\&  gnuplot -persist - 1>/dev/null 2>&1
+\&  gnuplot \-persist - 1>/dev/null 2>&1
 .Ve
 .PP
 Similar plot commands are supplied in the script \fBfunhist.plot\fR:
@@ -367,4 +367,4 @@ Similar plot commands are supplied in the script \fBfunhist.plot\fR:
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funimage.1
+++ b/man/man1/funimage.1
@@ -131,18 +131,18 @@
 .IX Title "funimage 1"
 .TH funimage 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfunimage \- create a FITS image from a Funtools data file\fR
+funimage \- create a FITS image from a Funtools data file
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funimage [\-a] <iname> <oname> [bitpix=n]
-funimage [\-l] <iname> <oname> <xcol:xdims> <ycol:ydims> <vcol> [bitpix=n]
-funimage [\-p x|y] <iname> <oname> [bitpix=n]
+\&\fBfunimage\fR [\-a] <iname> <oname> [bitpix=n]
+\&\fBfunimage\fR [\-l] <iname> <oname> <xcol:xdims> <ycol:ydims> <vcol> [bitpix=n]
+\&\fBfunimage\fR [\-p x|y] <iname> <oname> [bitpix=n]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 3
-\&  -a       # append to existing output file as an image extension
-\&  -l       # input is a list file containing xcol, ycol, value
-\&  -p [x|y] # project along x or y axis to create a 1D image
+\&  \-a       # append to existing output file as an image extension
+\&  \-l       # input is a list file containing xcol, ycol, value
+\&  \-p [x|y] # project along x or y axis to create a 1D image
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -243,7 +243,7 @@ In particular, the min value should be used whenever the
 minimum coordinate value is something other than one. For example:
 .PP
 .Vb 1
-\&  funimage -l foo.lst foo.fits xcol:0:512 ycol:0:512 value bitpix=-32
+\&  funimage \-l foo.lst foo.fits xcol:0:512 ycol:0:512 value bitpix=-32
 .Ve
 .PP
 The list feature also can be used to read unnamed columns from standard
@@ -251,7 +251,7 @@ input: simply replace the column name with a null string. Note
 that the dimension information is still required:
 .PP
 .Vb 5
-\&  funimage -l stdin foo.fits "":0:512 "":0:512 "" bitpix=-32
+\&  funimage \-l stdin foo.fits "":0:512 "":0:512 "" bitpix=-32
 \&  240 250 1
 \&  255 256 2
 \&  ...
@@ -270,7 +270,7 @@ example, consider the following text file (called foo.txt):
 \&  0         0
 .Ve
 .PP
-This text file defines two columns, x and y, each of data type 32\-bit int and
+This text file defines two columns, x and y, each of data type 32-bit int and
 image dimension 10. The command:
 .PP
 .Vb 1
@@ -380,14 +380,14 @@ A projection along the y axis can be performed on either the table or
 the image:
 .PP
 .Vb 4
-\&  funimage -p y ev.fits stdout | fundisp stdin
+\&  funimage \-p y ev.fits stdout | fundisp stdin
 \&              1          2          3          4          5
 \&     ---------- ---------- ---------- ---------- ----------
 \&  1:          1          2          3          4          5
 .Ve
 .PP
 .Vb 4
-\&  funimage -p y dim2.fits stdout | fundisp stdin
+\&  funimage \-p y dim2.fits stdout | fundisp stdin
 \&              1          2          3          4          5
 \&     ---------- ---------- ---------- ---------- ----------
 \&  1:          1          2          3          4          5
@@ -425,4 +425,4 @@ Display the \s-1FITS\s0 image generated from a blocked section of \s-1FITS\s0 bi
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funindex.1
+++ b/man/man1/funindex.1
@@ -131,20 +131,20 @@
 .IX Title "funindex 1"
 .TH funindex 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfunindex \- create an index for a column of a FITS binary table\fR
+funindex \- create an index for a column of a FITS binary table
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funindex <switches>  <iname> <key> [oname]
+\&\fBfunindex\fR <switches>  <iname> <key> [oname]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 7
 \&  NB: these options are not compatible with Funtools processing. Please
 \&  use the defaults instead.
-\&  -c        # compress output using gzip"
-\&  -a        # ASCII output, ignore -c (default: FITS table)"
-\&  -f        # FITS table output (default: FITS table)"
-\&  -l        # long output, i.e. with key value(s) (default: long)"
-\&  -s        # short output, i.e. no key value(s) (default: long)"
+\&  \-c        # compress output using gzip"
+\&  \-a        # ASCII output, ignore \-c (default: FITS table)"
+\&  \-f        # FITS table output (default: FITS table)"
+\&  \-l        # long output, i.e. with key value(s) (default: long)"
+\&  \-s        # short output, i.e. no key value(s) (default: long)"
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -176,4 +176,4 @@ This will generate an index named foo_y.idx, which will be used by funtools
 for filters involving the Y column.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funjoin.1
+++ b/man/man1/funjoin.1
@@ -131,24 +131,24 @@
 .IX Title "funjoin 1"
 .TH funjoin 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfunjoin \- join two or more FITS binary tables on specified columns\fR
+funjoin \- join two or more FITS binary tables on specified columns
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funjoin [switches] <ifile1> <ifile2> ... <ifilen> <ofile> 
+\&\fBfunjoin\fR [switches] <ifile1> <ifile2> ... <ifilen> <ofile> 
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 11
-\&  -a  cols             # columns to activate in all files
-\&  -a1 cols ... an cols # columns to activate in each file
-\&  -b  'c1:bvl,c2:bv2'  # blank values for common columns in all files
-\&  -bn 'c1:bv1,c2:bv2'  # blank values for columns in specific files
-\&  -j  col              # column to join in all files
-\&  -j1 col ... jn col   # column to join in each file
-\&  -m min               # min matches to output a row
-\&  -M max               # max matches to output a row
-\&  -s                   # add 'jfiles' status column
-\&  -S col               # add col as status column
-\&  -t tol               # tolerance for joining numeric cols [2 files only]
+\&  \-a  cols             # columns to activate in all files
+\&  \-a1 cols ... an cols # columns to activate in each file
+\&  \-b  'c1:bvl,c2:bv2'  # blank values for common columns in all files
+\&  \-bn 'c1:bv1,c2:bv2'  # blank values for columns in specific files
+\&  \-j  col              # column to join in all files
+\&  \-j1 col ... jn col   # column to join in each file
+\&  \-m min               # min matches to output a row
+\&  \-M max               # max matches to output a row
+\&  \-s                   # add 'jfiles' status column
+\&  \-S col               # add col as status column
+\&  \-t tol               # tolerance for joining numeric cols [2 files only]
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -179,13 +179,13 @@ columns in a given join.  For example, to join three files using the
 same key column for each file, use:
 .PP
 .Vb 1
-\&  funjoin -j key in1.fits in2.fits in3.fits out.fits
+\&  funjoin \-j key in1.fits in2.fits in3.fits out.fits
 .Ve
 .PP
 A different key can be specified for the third file in this way:
 .PP
 .Vb 1
-\&  funjoin -j key -j3 otherkey in1.fits in2.fits in3.fits out.fits
+\&  funjoin \-j key \-j3 otherkey in1.fits in2.fits in3.fits out.fits
 .Ve
 .PP
 The \fB\-a \*(L"cols\*(R"\fR switch (and \fB\-a1 \*(L"col1\*(R"\fR,
@@ -205,7 +205,7 @@ For example, to write out only those rows in which exactly two files
 have columns that match (i.e. one join):
 .PP
 .Vb 1
-\&  funjoin -j key -m 1 -M 1 in1.fits in2.fits in3.fits ... out.fits
+\&  funjoin \-j key \-m 1 \-M 1 in1.fits in2.fits in3.fits ... out.fits
 .Ve
 .PP
 A given row can have the requisite number of joins without all of the
@@ -213,7 +213,7 @@ files being joined (e.g. three files are being joined but only two
 have a given join key value). In this case, all of the columns of the
 non-joined file are written out, by default, using blanks (zeros or NULLs).
 The \fB\-b c1:bv1,c2:bv2\fR and
-\&\fB\-b1 'c1:bv1,c2:bv2' \-b2 'c1:bv1,c2:bv2' ...\fR
+\-b1 'c1:bv1,c2:bv2' \-b2 'c1:bv1,c2 - bv2' ...
 switches can be used to set the blank value for columns common to all
 files and/or columns in a specified file, respectively. Each blank value
 string contains a comma-separated list of column:blank_val specifiers.
@@ -222,7 +222,7 @@ value of \*(L"nan\*(R" means that the \s-1IEEE\s0 NaN (not\-a\-number) should be
 used. Thus, for example:
 .PP
 .Vb 1
-\&  funjoin -b "AKEY:???" -b1 "A:-1" -b3 "G:NaN,E:-1,F:-100" ...
+\&  funjoin \-b "AKEY:???" \-b1 "A:-1" \-b3 "G:NaN,E:-1,F:-100" ...
 .Ve
 .PP
 means that a non-joined \s-1AKEY\s0 column in any file will contain the
@@ -296,9 +296,9 @@ fundisp t3.fits
 Given these input files, the following funjoin command:
 .PP
 .Vb 3
-\&  funjoin -s -a1 "-B" -a2 "-D" -a3 "-E" -b \e
-\&  "AKEY:???" -b1 "AKEY:XXX,A:255" -b3 "G:NaN,E:-1,F:-100" \e
-\&  -j key t1.fits t2.fits t3.fits foo.fits
+\&  funjoin \-s \-a1 "\-B" \-a2 "\-D" \-a3 "\-E" \-b \e
+\&  "AKEY:???" \-b1 "AKEY:XXX,A:255" \-b3 "G:NaN,E:-1,F:-100" \e
+\&  \-j key t1.fits t2.fits t3.fits foo.fits
 .Ve
 .PP
 will join the files on the \s-1KEY\s0 column, outputting all columns except B
@@ -311,16 +311,16 @@ flag which files were used in each row:
 \&        AKEY    KEY      A       AKEY_2  KEY_2      C       AKEY_3  KEY_3        F           G   JFILES
 \&  ------------ ------ ------ ------------ ------ ------ ------------ ------ -------- ----------- --------
 \&         aaa      0      0          aaa      0      0          aaa      0        1      300.30        7
-\&         bbb      1      3          ???      0      0          ???      0     -100         nan        1
-\&         ccc      2      6          ccc      2      6          ???      0     -100         nan        3
+\&         bbb      1      3          ???      0      0          ???      0     \-100         nan        1
+\&         ccc      2      6          ccc      2      6          ???      0     \-100         nan        3
 \&         ddd      3      9          ???      0      0          ddd      3       10      400.40        5
-\&         eee      4     12          eee      4     12          ???      0     -100         nan        3
-\&         fff      5     15          ???      0      0          ???      0     -100         nan        1
+\&         eee      4     12          eee      4     12          ???      0     \-100         nan        3
+\&         fff      5     15          ???      0      0          ???      0     \-100         nan        1
 \&         ggg      6     18          ggg      6     18          ggg      6       19      100.10        7
-\&         hhh      7     21          ???      0      0          ???      0     -100         nan        1
-\&         XXX      0    255          iii      8     24          ???      0     -100         nan        2
+\&         hhh      7     21          ???      0      0          ???      0     \-100         nan        1
+\&         XXX      0    255          iii      8     24          ???      0     \-100         nan        2
 \&         XXX      0    255          ???      0      0          jjj      9       28      200.20        4
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funmerge.1
+++ b/man/man1/funmerge.1
@@ -131,16 +131,16 @@
 .IX Title "funmerge 1"
 .TH funmerge 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfunmerge \- merge one or more Funtools table files\fR
+funmerge \- merge one or more Funtools table files
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funmerge  [\-w|\-x] \-f [colname] <iname1> <iname2>  ... <oname>
+\&\fBfunmerge\fR  [\-w|\-x] \-f [colname] <iname1> <iname2>  ... <oname>
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 3
-\&  -f    # output a column specifying file from which this event came
-\&  -w    # adjust position values using WCS info
-\&  -x    # adjust position values using WCS info and save old values
+\&  \-f    # output a column specifying file from which this event came
+\&  \-w    # adjust position values using WCS info
+\&  \-x    # adjust position values using WCS info and save old values
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -198,18 +198,18 @@ each row in the column called \*(L"\s-1FILE\s0\*(R" (along with the correspondin
 file name in the header):
 .PP
 .Vb 1
-\&  [sh] funmerge -f "FILE" test.ev test2.ev merge.ev
+\&  [sh] funmerge \-f "FILE" test.ev test2.ev merge.ev
 .Ve
 .PP
 Merge two tables with \s-1WCS\s0 alignment, saving the old position values in
 2 additional columns:
 .PP
 .Vb 1
-\&  [sh] funmerge -x test.ev test2.ev merge.ev
+\&  [sh] funmerge \-x test.ev test2.ev merge.ev
 .Ve
 .PP
 This program only works on raw event files and binary tables. We have
 not yet implemented image and array merging.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funsky.1
+++ b/man/man1/funsky.1
@@ -131,23 +131,23 @@
 .IX Title "funsky 1"
 .TH funsky 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfunsky \- convert between image and sky coordinates\fR
+funsky \- convert between image and sky coordinates
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 4
-\&  funsky iname[ext]               # RA,Dec (deg) or image pix from stdin
-\&  funsky iname[ext] [lname]       # RA, Dec (deg) or image pix from list
-\&  funsky iname[ext] [col1] [col2]         # named cols:units from stdin
-\&  funsky iname[ext] [lname] [col1] [col2] # named cols:units from list
+\&\fBfunsky\fR iname[ext]               # RA,Dec (deg) or image pix from stdin
+\&\fBfunsky\fR iname[ext] [lname]       # RA, Dec (deg) or image pix from list
+\&\fBfunsky\fR iname[ext] [col1] [col2]         # named cols:units from stdin
+\&\fBfunsky\fR iname[ext] [lname] [col1] [col2] # named cols:units from list
 .Ve
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 5
-\&  -d        # always use integer tlmin conversion (as ds9 does)
-\&  -r        # convert x,y to RA,Dec (default: convert RA,Dec to x,y)
-\&  -o        # include offset from the nominal target position (in arcsec)
-\&  -v        # display input values also (default: display output only)
-\&  -T        # output display in rdb format (w/header,tab delimiters)
+\&  \-d        # always use integer tlmin conversion (as ds9 does)
+\&  \-r        # convert x,y to RA,Dec (default: convert RA,Dec to x,y)
+\&  \-o        # include offset from the nominal target position (in arcsec)
+\&  \-v        # display input values also (default: display output only)
+\&  \-T        # output display in rdb format (w/header,tab delimiters)
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -270,7 +270,7 @@ examples will serve to illustrate the options:
 .Ve
 .PP
 .Vb 4
-\&  [sh] cat im.in | funsky -r snr.ev :d :d
+\&  [sh] cat im.in | funsky \-r snr.ev :d :d
 \&  344.740432    58.606523
 \&  344.731900    58.607634
 \&  344.725500    58.614301
@@ -304,7 +304,7 @@ and/or units:
 .Ve
 .PP
 .Vb 4
-\&  [sh] funsky -r snr.ev im.in :d :d
+\&  [sh] funsky \-r snr.ev im.in :d :d
 \&    344.740432    58.606523
 \&    344.731900    58.607634
 \&    344.725500    58.614301
@@ -332,7 +332,7 @@ coordinates should be pre-pended to each line. For example:
 .Ve
 .PP
 .Vb 4
-\&  [sh] funsky -v snr.ev dd.in MYRA:d MYDEC:d
+\&  [sh] funsky \-v snr.ev dd.in MYRA:d MYDEC:d
 \&    344.740432    58.606523       510.00       510.00
 \&    344.731900    58.607634       512.00       510.50
 \&    344.725500    58.614301       513.50       513.50
@@ -346,7 +346,7 @@ sky units):
 .PP
 .Vb 7
 \&  # output table in non-verbose mode
-\&  [sh] funsky -T snr.ev dd.in MYRA:d MYDEC:d
+\&  [sh] funsky \-T snr.ev dd.in MYRA:d MYDEC:d
 \&             X               Y
 \&  ------------    ------------
 \&        510.00          510.00
@@ -356,7 +356,7 @@ sky units):
 .PP
 .Vb 9
 \&  # output table in verbose mode
-\&  [sh] funsky -T -v snr.ev dd.in MYRA:d MYDEC:d
+\&  [sh] funsky \-T \-v snr.ev dd.in MYRA:d MYDEC:d
 \&  # IFILE = /Users/eric/data/snr.ev
 \&  # ICOL1 = MYRA
 \&  # ICOL2 = MYDEC
@@ -382,4 +382,4 @@ small discrepancy with ds9's converted values for floating point
 data. We will remedy this conflict in the future, maybe.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funtable.1
+++ b/man/man1/funtable.1
@@ -131,18 +131,18 @@
 .IX Title "funtable 1"
 .TH funtable 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfuntable \- copy selected rows from a Funtools file to a FITS binary table\fR
+funtable \- copy selected rows from a Funtools file to a FITS binary table
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funtable [\-a] [\-i|\-z] [\-m] [\-s cols] <iname> <oname> [columns]
+\&\fBfuntable\fR [\-a] [\-i|\-z] [\-m] [\-s cols] <iname> <oname> [columns]
 .SH "OPTIONS"
 .IX Header "OPTIONS"
 .Vb 5
-\&  -a    # append to existing output file as a table extension
-\&  -i    # for image data, only generate X and Y columns
-\&  -m    # for tables, write a separate file for each region
-\&  -s "col1 ..." # columns on which to sort
-\&  -z    # for image data, output zero-valued pixels
+\&  \-a    # append to existing output file as a table extension
+\&  \-i    # for image data, only generate X and Y columns
+\&  \-m    # for tables, write a separate file for each region
+\&  \-s "col1 ..." # columns on which to sort
+\&  \-z    # for image data, output zero-valued pixels
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -196,15 +196,15 @@ region id of each row:
 \&  [sh $] funtable "test.ev[time-(int)time>=.99&&annulus(0 0 0 10 n=3)]" stdout 'x y time $REGION' | fundisp stdin
 \&          X        Y                  TIME     REGION
 \&   -------- -------- --------------------- ----------
-\&          5       -6           40.99000000          3
-\&          4       -5           59.99000000          2
-\&         -1        0          154.99000000          1
-\&         -2        1          168.99000000          1
-\&         -3        2          183.99000000          2
-\&         -4        3          199.99000000          2
-\&         -5        4          216.99000000          2
-\&         -6        5          234.99000000          3
-\&         -7        6          253.99000000          3
+\&          5       \-6           40.99000000          3
+\&          4       \-5           59.99000000          2
+\&         \-1        0          154.99000000          1
+\&         \-2        1          168.99000000          1
+\&         \-3        2          183.99000000          2
+\&         \-4        3          199.99000000          2
+\&         \-5        4          216.99000000          2
+\&         \-6        5          234.99000000          3
+\&         \-7        6          253.99000000          3
 .Ve
 .PP
 Here only rows with the proper fractional time and whose position also is
@@ -214,18 +214,18 @@ Columns can be excluded from display using a minus sign before the
 column:
 .PP
 .Vb 12
-\&  [sh $] funtable "test.ev[time-(int)time>=.99]" stdout "-time" | fundisp stdin
+\&  [sh $] funtable "test.ev[time-(int)time>=.99]" stdout "\-time" | fundisp stdin
 \&          X        Y      PHA         PI          DX          DY
 \&   -------- -------- -------- ---------- ----------- -----------
-\&          5       -6        5         -6        5.50       -6.50
-\&          4       -5        4         -5        4.50       -5.50
-\&         -1        0       -1          0       -1.50        0.50
-\&         -2        1       -2          1       -2.50        1.50
-\&         -3        2       -3          2       -3.50        2.50
-\&         -4        3       -4          3       -4.50        3.50
-\&         -5        4       -5          4       -5.50        4.50
-\&         -6        5       -6          5       -6.50        5.50
-\&         -7        6       -7          6       -7.50        6.50
+\&          5       \-6        5         \-6        5.50       \-6.50
+\&          4       \-5        4         \-5        4.50       \-5.50
+\&         \-1        0       \-1          0       \-1.50        0.50
+\&         \-2        1       \-2          1       \-2.50        1.50
+\&         \-3        2       \-3          2       \-3.50        2.50
+\&         \-4        3       \-4          3       \-4.50        3.50
+\&         \-5        4       \-5          4       \-5.50        4.50
+\&         \-6        5       \-6          5       \-6.50        5.50
+\&         \-7        6       \-7          6       \-7.50        6.50
 .Ve
 .PP
 All columns except the time column are written.
@@ -309,7 +309,7 @@ quoted to protect it from the shell) and will be expanded to be the id
 number of the associated region. For example:
 .Sp
 .Vb 1
-\&  funtable -m input.fits'[cir(512,512,1);cir(520,520,1)...]' 'foo.goo_$n.fits'
+\&  funtable \-m input.fits'[cir(512,512,1);cir(520,520,1)...]' 'foo.goo_$n.fits'
 .Ve
 .Sp
 will generate files named foo.goo_0.fits (for rows not in any region but
@@ -321,7 +321,7 @@ If \f(CW$n\fR is not specified, then the region id will be placed before
 the first dot (.) in the filename. Thus:
 .Sp
 .Vb 1
-\&  funtable -m input.fits'[cir(512,512,1);cir(520,520,1)...]' foo.evt.fits
+\&  funtable \-m input.fits'[cir(512,512,1);cir(520,520,1)...]' foo.evt.fits
 .Ve
 .Sp
 will generate files named foo0.evt.fits (for rows not in any region but
@@ -332,7 +332,7 @@ If no dot is specified in the root output file name, then
 the region id will be appended to the filename. Thus:
 .Sp
 .Vb 1
-\&  funtable -m input.fits'[cir(512,512,1);cir(520,520,1)...]' 'foo_evt'
+\&  funtable \-m input.fits'[cir(512,512,1);cir(520,520,1)...]' 'foo_evt'
 .Ve
 .Sp
 will generate files named foo_evt0 (for rows not in any region but
@@ -353,4 +353,4 @@ be output with their \*(L"\s-1VALUE\s0\*(R" column set to zero. Obviously, this
 switch does not make sense when individual events are output.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man1/funtbl.1
+++ b/man/man1/funtbl.1
@@ -131,10 +131,10 @@
 .IX Title "funtbl 1"
 .TH funtbl 1 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBfuntbl \- extract a table from Funtools ASCII output\fR
+funtbl \- extract a table from Funtools ASCII output
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-funtable [\-c cols] [\-h] [\-n table] [\-p prog] [\-s sep] <iname>
+\&\fBfuntable\fR [\-c cols] [\-h] [\-n table] [\-p prog] [\-s sep] <iname>
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
 [\s-1NB:\s0 This program has been deprecated in favor of the \s-1ASCII\s0 text processing
@@ -165,7 +165,7 @@ describing program usage.
 For example, consider the output from the following funcnts command:
 .PP
 .Vb 10
-\&  [sh] funcnts -sr snr.ev "ann 512 512 0 9 n=3"
+\&  [sh] funcnts \-sr snr.ev "ann 512 512 0 9 n=3"
 \&  # source
 \&  #   data file:        /proj/rd/data/snr.ev
 \&  #   arcsec/pixel:     8
@@ -214,7 +214,7 @@ There are four tables in this output. To extract the last one, you
 can execute:
 .PP
 .Vb 4
-\&  [sh] funcnts -s snr.ev "ann 512 512 0 9 n=3" | funtbl -n 4
+\&  [sh] funcnts \-s snr.ev "ann 512 512 0 9 n=3" | funtbl \-n 4
 \&  1 147.000 25 147.000 25
 \&  2 478.000 84 625.000 109
 \&  3 817.000 140 1442.000 249
@@ -227,7 +227,7 @@ To extract only columns 1,2, and 4 from the last example (but with a header
 prepended and tabs between columns), you can execute:
 .PP
 .Vb 5
-\&  [sh] funcnts -s snr.ev "ann 512 512 0 9 n=3" | funtbl -c "1 2 4" -h -n 4 -s "\et"
+\&  [sh] funcnts \-s snr.ev "ann 512 512 0 9 n=3" | funtbl \-c "1 2 4" \-h \-n 4 \-s "\et"
 \&  #reg    counts  sumcnts
 \&  1       147.000 147.000
 \&  2       478.000 625.000
@@ -238,7 +238,7 @@ Of course, if the output has previously been saved in a file named
 foo.out, the same result can be obtained by executing:
 .PP
 .Vb 5
-\&  [sh] funtbl -c "1 2 4" -h -n 4 -s "\et" foo.out
+\&  [sh] funtbl \-c "1 2 4" \-h \-n 4 \-s "\et" foo.out
 \&  #reg    counts  sumcnts
 \&  1       147.000 147.000
 \&  2       478.000 625.000
@@ -246,4 +246,4 @@ foo.out, the same result can be obtained by executing:
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funclose.3
+++ b/man/man3/funclose.3
@@ -131,7 +131,7 @@
 .IX Title "funclose 3"
 .TH funclose 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunClose \- close a Funtools data file\fR
+FunClose \- close a Funtools data file
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -157,4 +157,4 @@ you can call \fIFunFlush()\fR
 explicitly).
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funcolumnactivate.3
+++ b/man/man3/funcolumnactivate.3
@@ -131,7 +131,7 @@
 .IX Title "funcolumnactivate 3"
 .TH funcolumnactivate 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunColumnActivate \- activate Funtools columns\fR
+FunColumnActivate \- activate Funtools columns
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -244,7 +244,7 @@ select columns in one command. For example, consider the following:
 .PP
 .Vb 9
 \&  # reorder and de-activate
-\&  fundisp snr.ev'[cir 512 512 .1]' "time pi pha + -x -y"
+\&  fundisp snr.ev'[cir 512 512 .1]' "time pi pha + \-x \-y"
 \&                   TIME       PI      PHA       DX       DY
 \&  --------------------- -------- -------- -------- --------
 \&      79493997.45854475        7        6      578      574
@@ -260,7 +260,7 @@ Note that this is different from:
 .PP
 .Vb 9
 \&  # probably not what you want ...
-\&  fundisp snr.ev'[cir 512 512 .1]' "time pi pha -x -y +"
+\&  fundisp snr.ev'[cir 512 512 .1]' "time pi pha \-x \-y +"
 \&                   TIME       PI      PHA        Y        X       DX       DY
 \&  --------------------- -------- -------- -------- -------- -------- --------
 \&      79493997.45854475        7        6      512      512      578      574
@@ -307,7 +307,7 @@ activated (i.e., in this case, written to the new file).  For example:
 will process only the three columns mentioned, while:
 .PP
 .Vb 1
-\&  funtable test.ev foo.ev "-time"
+\&  funtable test.ev foo.ev "\-time"
 .Ve
 .PP
 will process all columns except \*(L"time\*(R".
@@ -327,4 +327,4 @@ of calling it this way:
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funcolumnlookup.3
+++ b/man/man3/funcolumnlookup.3
@@ -131,7 +131,7 @@
 .IX Title "funcolumnlookup 3"
 .TH funcolumnlookup 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunColumnLookup \- lookup a Funtools column\fR
+FunColumnLookup \- lookup a Funtools column
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -160,19 +160,19 @@ the following information will be returned:
 .IP "\(bu" 4
 A: \s-1ASCII\s0 characters
 .IP "\(bu" 4
-B: unsigned 8\-bit char
+B: unsigned 8-bit char
 .IP "\(bu" 4
-I: signed 16\-bit int
+I: signed 16-bit int
 .IP "\(bu" 4
-U: unsigned 16\-bit int (not standard \s-1FITS\s0)
+U: unsigned 16-bit int (not standard \s-1FITS\s0)
 .IP "\(bu" 4
-J: signed 32\-bit int
+J: signed 32-bit int
 .IP "\(bu" 4
-V: unsigned 32\-bit int (not standard \s-1FITS\s0)
+V: unsigned 32-bit int (not standard \s-1FITS\s0)
 .IP "\(bu" 4
-E: 32\-bit float
+E: 32-bit float
 .IP "\(bu" 4
-D: 64\-bit float
+D: 64-bit float
 .RE
 .RS 4
 .RE
@@ -217,4 +217,4 @@ example:
 only returns information about the size of the phas vector.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funcolumnselect.3
+++ b/man/man3/funcolumnselect.3
@@ -131,7 +131,7 @@
 .IX Title "funcolumnselect 3"
 .TH funcolumnselect 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunColumnSelect \- select Funtools columns\fR
+FunColumnSelect \- select Funtools columns
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -179,19 +179,19 @@ following basic data types are recognized:
 .IP "\(bu" 4
 A: \s-1ASCII\s0 characters
 .IP "\(bu" 4
-B: unsigned 8\-bit char
+B: unsigned 8-bit char
 .IP "\(bu" 4
-I: signed 16\-bit int
+I: signed 16-bit int
 .IP "\(bu" 4
-U: unsigned 16\-bit int (not standard \s-1FITS\s0)
+U: unsigned 16-bit int (not standard \s-1FITS\s0)
 .IP "\(bu" 4
-J: signed 32\-bit int
+J: signed 32-bit int
 .IP "\(bu" 4
-V: unsigned 32\-bit int (not standard \s-1FITS\s0)
+V: unsigned 32-bit int (not standard \s-1FITS\s0)
 .IP "\(bu" 4
-E: 32\-bit float
+E: 32-bit float
 .IP "\(bu" 4
-D: 64\-bit float
+D: 64-bit float
 .RE
 .RS 4
 .Sp
@@ -276,7 +276,7 @@ array. By default, this offset value is set to zero and the data
 specified starts at the beginning of the array. The offset usually
 is specified in terms of the data type of the column. Thus an offset
 specification of [5] means a 20\-byte offset if the data type is a
-32\-bit integer, and a 40\-byte offset for a double. If you want to
+32-bit integer, and a 40\-byte offset for a double. If you want to
 specify a byte offset instead of an offset tied to the column data type,
 precede the offset value with 'B', e.g. [B6] means a 6\-bye offset,
 regardless of the column data type.
@@ -593,7 +593,7 @@ wanted to read columns into contiguous arrays, you specify \fBorg=soa\fR:
 .PP
 Note that the only modification to the call is in the plist string.
 .PP
-Of course, instead of using staticly allocated arrays, you also can specify
+Of course, instead of using statically allocated arrays, you also can specify
 dynamically allocated pointers:
 .PP
 .Vb 7
@@ -661,4 +661,4 @@ for working examples of how
 \&\fIFunColumnSelect()\fR is used.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funflush.3
+++ b/man/man3/funflush.3
@@ -131,7 +131,7 @@
 .IX Title "funflush 3"
 .TH funflush 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunFlush \- flush data to output file\fR
+FunFlush \- flush data to output file
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -209,4 +209,4 @@ file:
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funimageget.3
+++ b/man/man3/funimageget.3
@@ -131,7 +131,7 @@
 .IX Title "funimageget 3"
 .TH funimageget 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunImageGet \- get an image or image section\fR
+FunImageGet \- get an image or image section
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -329,4 +329,4 @@ See Binning \s-1FITS\s0 Binary Tables and
 Non-FITS Event Files for more information.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funimageput.3
+++ b/man/man3/funimageput.3
@@ -131,7 +131,7 @@
 .IX Title "funimageput 3"
 .TH funimageput 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunImagePut \- put an image to a Funtools file\fR
+FunImagePut \- put an image to a Funtools file
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -190,7 +190,7 @@ Thus, a simple program to generate a \s-1FITS\s0 image might look like this:
 \&    ... fill dbuf ...
 \&  }
 \&  /* put the image (header will be generated automatically */
-\&  if( !FunImagePut(fun, buf, dim1, dim2, -64, NULL) )
+\&  if( !FunImagePut(fun, buf, dim1, dim2, \-64, NULL) )
 \&    gerror(stderr, "could not FunImagePut: %s\en", argv[1]);
 \&  FunClose(fun);
 \&  free(dbuf);
@@ -222,4 +222,4 @@ image padding. However, this is not necessary if you subsequently call
 \&\fIFunClose()\fR without doing any other I/O to the \s-1FITS\s0 file.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funimagerowget.3
+++ b/man/man3/funimagerowget.3
@@ -131,7 +131,7 @@
 .IX Title "funimagerowget 3"
 .TH funimagerowget 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunImageRowGet \- get row(s) of an image\fR
+FunImageRowGet \- get row(s) of an image
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -212,4 +212,4 @@ above for specifying binning columns in
 \&\fB\f(BIFunImageRowGet()\fB\fR.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funimagerowput.3
+++ b/man/man3/funimagerowput.3
@@ -131,7 +131,7 @@
 .IX Title "funimagerowput 3"
 .TH funimagerowput 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunImageRowPut \- put row(s) of an image\fR
+FunImageRowPut \- put row(s) of an image
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -199,4 +199,4 @@ image padding. However, this is not necessary if you subsequently call
 \&\fIFunClose()\fR without doing any other I/O to the \s-1FITS\s0 file.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funinfoget.3
+++ b/man/man3/funinfoget.3
@@ -131,7 +131,7 @@
 .IX Title "funinfoget 3"
 .TH funinfoget 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunInfoGet \- get information from Funtools struct\fR
+FunInfoGet \- get information from Funtools struct
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -332,4 +332,4 @@ works internally. We are happy to help you write such programs as the
 need arises.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funinfoput.3
+++ b/man/man3/funinfoput.3
@@ -131,7 +131,7 @@
 .IX Title "funinfoput 3"
 .TH funinfoput 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunInfoPut \- put information into a Funtools struct\fR
+FunInfoPut \- put information into a Funtools struct
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -243,4 +243,4 @@ Once the \s-1FUN_OPS\s0 variable has been reset, the next I/O call on the
 output extension will output the header, as expected.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funlib.3
+++ b/man/man3/funlib.3
@@ -131,7 +131,7 @@
 .IX Title "funlib 3"
 .TH funlib 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunLib: the Funtools Programming Interface\fR
+FunLib \- the Funtools Programming Interface
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 A description of the Funtools library.
@@ -180,19 +180,19 @@ on your system:
 For example, on a Solaris system using gcc, use the following link line:
 .PP
 .Vb 1
-\&  gcc -o foo foo.c -lfuntools -lsocket -lnsl -ldl -lm
+\&  gcc \-o foo foo.c \-lfuntools \-lsocket \-lnsl \-ldl \-lm
 .Ve
 .PP
 On a Solaris system using Solaris cc, use the following link line:
 .PP
 .Vb 1
-\&  gcc -o foo foo.c -lfuntools -lsocket -lnsl -lm
+\&  gcc \-o foo foo.c \-lfuntools \-lsocket \-lnsl \-lm
 .Ve
 .PP
 On a Linux system using gcc, use the following link line:
 .PP
 .Vb 1
-\&  gcc -o foo foo.c -lfuntools -ldl -lm
+\&  gcc \-o foo foo.c \-lfuntools \-ldl \-lm
 .Ve
 .PP
 Once configure has built a Makefile on your platform, the required
@@ -202,7 +202,7 @@ Linux you will find:
 .PP
 .Vb 3
 \&  grep EXTRA_LIBS Makefile
-\&  EXTRA_LIBS      =  -ldl
+\&  EXTRA_LIBS      =  \-ldl
 \&  ...
 .Ve
 .PP
@@ -279,7 +279,7 @@ Finally, you can write the resulting image to disk using
 \&\fIFunImagePut()\fR:
 .PP
 .Vb 1
-\&  FunImagePut(fun2, buf, dim1, dim2, -32, NULL);
+\&  FunImagePut(fun2, buf, dim1, dim2, \-32, NULL);
 .Ve
 .PP
 Note that Funtools automatically takes care of book-keeping tasks such as
@@ -375,7 +375,7 @@ math library (and the dynamic load library, if the latter is available
 on your system):
 .PP
 .Vb 1
-\&  gcc -o foo foo.c -lfuntools -ldl -lm
+\&  gcc \-o foo foo.c \-lfuntools \-ldl \-lm
 .Ve
 .PP
 If gcc is used, Funtools filtering can be performed using dynamically
@@ -522,4 +522,4 @@ void FunFlush(Fun fun, char *plist)
 void FunClose(Fun fun)
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funopen.3
+++ b/man/man3/funopen.3
@@ -131,7 +131,7 @@
 .IX Title "funopen 3"
 .TH funopen 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunOpen \- open a Funtools data file\fR
+FunOpen \- open a Funtools data file
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -269,4 +269,4 @@ Fun handle that is used in subsequent Funtools calls. On error, \s-1NULL\s0
 is returned.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funparamget.3
+++ b/man/man3/funparamget.3
@@ -131,7 +131,7 @@
 .IX Title "funparamget 3"
 .TH funparamget 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunParamGet \- get a Funtools param value\fR
+FunParamGet \- get a Funtools param value
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -189,7 +189,7 @@ from the primary header on a per-parameter basis:
 \&  FunParamGeti(FUN_PRIMARY(fun), "NAXIS1", 0, 0, &got); # primary header
 .Ve
 .PP
-\&\fB\s-1NB:\s0 \s-1FUN_PRIMARY\s0 is deprecated.\fR
+\s-1NB - \s0 \s-1FUN_PRIMARY\s0 is deprecated.
 It makes use of a global parameter and therefore will not not
 appropriate for threaded applications, when we make funtools
 thread\-safe. We recommend use of \fIFunInfoPut()\fR to switch between the
@@ -234,7 +234,7 @@ raw 80\-character \s-1FITS\s0 card instead.  In particular, if you set the
 .PP
 Alternatively, if the \s-1FUN_RAW\s0 macro is applied to the name, then the
 80\-character raw \s-1FITS\s0 card is returned instead.  
-\&\fB\s-1NB:\s0 \s-1FUN_RAW\s0 is deprecated.\fR 
+\s-1NB - \s0 \s-1FUN_RAW\s0 is deprecated. 
 It makes use of a global parameter and therefore will not not
 appropriate for threaded applications, when we make funtools
 thread\-safe. We recommend use of \fIFunInfoPut()\fR to switch between the
@@ -259,4 +259,4 @@ header cards in a given extension and print out the raw card, use:
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funparamput.3
+++ b/man/man3/funparamput.3
@@ -131,7 +131,7 @@
 .IX Title "funparamput 3"
 .TH funparamput 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunParamPut \- put a Funtools param value\fR
+FunParamPut \- put a Funtools param value
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -253,4 +253,4 @@ set the append argument to a non-zero value and the parameter did not
 already exist in the file.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funref.3
+++ b/man/man3/funref.3
@@ -131,7 +131,7 @@
 .IX Title "funref 3"
 .TH funref 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunRef: the Funtools Reference Handle\fR
+FunRef \- the Funtools Reference Handle
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 A description of how to use a Funtools reference handle to connect a
@@ -284,4 +284,4 @@ is closed \fBbefore\fR the input file:
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funtablerowget.3
+++ b/man/man3/funtablerowget.3
@@ -131,7 +131,7 @@
 .IX Title "funtablerowget 3"
 .TH funtablerowget 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunTableRowGet \- get Funtools rows\fR
+FunTableRowGet \- get Funtools rows
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 .Vb 1
@@ -192,8 +192,8 @@ will be the same as the second argument, if the latter is non\-NULL).
 \&      ev = buf+i;
 \&      /* rearrange some values. etc. */
 \&      ev->energy = (ev->pi+ev->pha)/2.0;
-\&      ev->pha = -ev->pha;
-\&      ev->pi = -ev->pi;
+\&      ev->pha = \-ev->pha;
+\&      ev->pi = \-ev->pi;
 \&    }
 \&    /* write out this batch of rows */
 \&    FunTableRowPut(fun2, buf, got, 0, NULL);
@@ -213,4 +213,4 @@ Note that \fIFunTableRowGet()\fR also can be called as \fIFunEventsGet()\fR, for
 backward compatibility.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man3/funtablerowput.3
+++ b/man/man3/funtablerowput.3
@@ -131,7 +131,7 @@
 .IX Title "funtablerowput 3"
 .TH funtablerowput 3 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunTableRowPut \- put Funtools rows\fR
+FunTableRowPut \- put Funtools rows
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 int FunTableRowPut(Fun fun, void *rows, int nev, int idx, char *plist)
@@ -294,4 +294,4 @@ Note that \fIFunTableRowPut()\fR also can be called as \fIFunEventsPut()\fR, for
 backward compatibility.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funcombine.7
+++ b/man/man7/funcombine.7
@@ -128,54 +128,121 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "regdiff n"
-.TH regdiff n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funcombine 7"
+.TH funcombine 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBRegDiff:Differences Between Funtools and IRAF Regions\fR
+FunCombine \- Combining Region and Table Filters
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-Describes the differences between Funtools/ds9 regions and the old \s-1IRAF/PROS\s0
-regions.
+This document discusses the conventions for combining region and table
+filters, especially with regards to the comma operator.
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
-We have tried to make Funtools regions compatible with their
-predecessor, \s-1IRAF/PROS\s0 regions. For simple regions and simple boolean
-algebra between regions, there should be no difference between the two
-implementations.  The following is a list of differences and
-incompatibilities between the two:
-.IP "\(bu" 4
-If a pixel is covered by two different regions expressions,
-Funtools assigns the mask value of the \fBfirst\fR region that
-contains that pixel.  That is, successive regions \fBdo not\fR
-overwrite previous regions in the mask, as was the case with the
-original \s-1PROS\s0 regions.  This means that one must define overlapping
-regions in the reverse order in which they were defined in \s-1PROS\s0.  If
-region N is fully contained within region M, then N should be defined
-\&\fBbefore\fR M, or else it will be \*(L"covered up\*(R" by the latter. This
-change is necessitated by the use of optimized filter compilation, i.e.,
-Funtools only tests individual regions until a proper match is made.
-.IP "\(bu" 4
-The \fB\s-1PANDA\s0\fR region has replaced the old \s-1PROS\s0 syntax in which
-a \fB\s-1PIE\s0\fR accelerator was combined with an \fB\s-1ANNULUS\s0\fR accelerator
-using \fB\s-1AND\s0\fR. That is,
-.Sp
+\&\fBComma Conventions\fR
+.PP
+Filter specifications consist of a series of boolean expressions,
+separated by commas. These expressions can be table filters,
+spatial region filters, or combinations thereof. Unfortunately,
+common usage requires that the comma operator must act differently
+in different situations. Therefore, while its use is intuitive in
+most cases, commas can be a source of confusion.
+.PP
+According to long-standing usage in \s-1IRAF\s0, when a comma separates two
+table filters, it takes on the meaning of a boolean \fBand\fR. Thus:
+.PP
 .Vb 1
-\&  ANNULUS(20,20,0,15,n=4) & PIE(20,20,0,360,n=3)
+\&  foo.fits[pha==1,pi==2]
 .Ve
-.Sp
-has been replaced by:
-.Sp
+.PP
+is equivalent to:
+.PP
 .Vb 1
-\&  PANDA(20,20,0,360,3,0,15,4)
+\&  foo.fits[pha==1 && pi==2]
 .Ve
-.Sp
-The \s-1PROS\s0 syntax was inconsistent with the meaning of the \fB\s-1AND\s0\fR operator.
+.PP
+When a comma separates two spatial region filters, however, it has
+traditionally taken on the meaning of a boolean \fBor\fR. Thus:
+.PP
+.Vb 1
+\&  foo.fits[circle(10,10,3),ellipse(20,20,8,5)]
+.Ve
+.PP
+is equivalent to:
+.PP
+.Vb 1
+\&  foo.fits[circle(10,10,3) || ellipse(20,20,8,5)]
+.Ve
+.PP
+(except that in the former case, each region is given a unique id
+in programs such as funcnts).
+.PP
+Region and table filters can be combined:
+.PP
+.Vb 1
+\&  foo.fits[circle(10,10,3),pi=1:5]
+.Ve
+.PP
+or even:
+.PP
+.Vb 1
+\&  foo.fits[pha==1&&circle(10,10,3),pi==2&&ellipse(20,20,8,5)]
+.Ve
+.PP
+In these cases, it is not obvious whether the command should utilize an
+\&\fBor\fR or \fBand\fR operator. We therefore arbitrarily chose to
+implement the following rule:
 .IP "\(bu" 4
-The meaning of pure numbers (i.e., without format specifiers) in 
-regions has been clarified, as has the syntax for specifying coordinate
-systems. See the general discussion on
-Spatial Region Filtering
-for more information.
+if both expressions contain a region, the operator used is \fBor\fR.
+.IP "\(bu" 4
+if one (or both) expression(s) does not contain a region, the operator
+used is \fBand\fR.
+.PP
+This rule handles the cases of pure regions and pure column filters properly.
+It unambiguously assigns the boolean \fBand\fR to all mixed cases. Thus:
+.PP
+.Vb 1
+\&  foo.fits[circle(10,10,3),pi=1:5]
+.Ve
+.PP
+and
+.PP
+.Vb 1
+\&  foo.fits[pi=1:5,circle(10,10,3)]
+.Ve
+.PP
+both are equivalent to:
+.PP
+.Vb 1
+\&  foo.fits[circle(10,10,3) && pi=1:5]
+.Ve
+.PP
+[\s-1NB:\s0 This arbitrary rule \fBreplaces the previous arbitrary rule\fR
+(pre\-funtools 1.2.3) which stated:
+.IP "\(bu" 4
+if the 2nd expression contains a region, the operator used is \fBor\fR.
+.IP "\(bu" 4
+if the 2nd expression does not contain a region, the operator
+used is \fBand\fR.
+.PP
+In that scenario, the \fBor\fR operator was implied by:
+.PP
+.Vb 1
+\&  pha==4,circle 5 5 1
+.Ve
+.PP
+while the \fBand\fR operator was implied by
+.PP
+.Vb 1
+\&  circle 5 5 1,pha==4
+.Ve
+.PP
+Experience showed that this non-commutative treatment of the comma
+operator was confusing and led to unexpected results.]
+.PP
+The comma rule must be considered provisional: comments and complaints
+are welcome to help clarify the matter. Better still, we recommend
+that the comma operator be avoided in such cases in favor of an
+explicit boolean operator.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funds9.7
+++ b/man/man7/funds9.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funds9 n"
-.TH funds9 n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funds9 7"
+.TH funds9 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunDS9: Funtools and DS9 Image Display\fR
+FunDS9 \- Funtools and DS9 Image Display
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 Describes how funtools can be integrated into the ds9 Analysis menu.
@@ -213,4 +213,4 @@ Aside from the units, the results should be identical to the file-based
 results.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funenv.7
+++ b/man/man7/funenv.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funenv n"
-.TH funenv n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funenv 7"
+.TH funenv 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunEnv: Funtools Environment Variables\fR
+FunEnv \- Funtools Environment Variables
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 Describes the environment variables which can be used to tailor the overall
@@ -204,7 +204,7 @@ of each environment variable is one of the standard \s-1FITS\s0 bitpix values
 create a floating array, then use:
 .Sp
 .Vb 1
-\&  setenv FITS_BITPIX -32
+\&  setenv FITS_BITPIX \-32
 .Ve
 .Sp
 in preference to adding a bitpix specification to each filename:
@@ -349,4 +349,4 @@ but care should be taken to reset its value to false when debugging is
 complete.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funfiles.7
+++ b/man/man7/funfiles.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funfiles n"
-.TH funfiles n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funfiles 7"
+.TH funfiles 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunFiles: Funtools Data Files\fR
+FunFiles \- Funtools Data Files
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document describes the data file formats (\s-1FITS\s0, array, raw
@@ -247,21 +247,21 @@ record:
 Data types follow standard conventions for \s-1FITS\s0 binary tables, but include
 two extra unsigned types ('U' and 'V'):
 .IP "\(bu" 4
-\&\fBB\fR \*(-- unsigned 8\-bit char
+\&\fBB\fR \*(-- unsigned 8-bit char
 .IP "\(bu" 4
-\&\fBI\fR \*(-- signed 16\-bit int
+\&\fBI\fR \*(-- signed 16-bit int
 .IP "\(bu" 4
-\&\fBJ\fR \*(-- signed 32\-bit int
+\&\fBJ\fR \*(-- signed 32-bit int
 .IP "\(bu" 4
-\&\fBK\fR \*(-- signed 64\-bit int
+\&\fBK\fR \*(-- signed 64-bit int
 .IP "\(bu" 4
-\&\fBE\fR \*(-- 32\-bit float
+\&\fBE\fR \*(-- 32-bit float
 .IP "\(bu" 4
-\&\fBD\fR \*(-- 64\-bit float
+\&\fBD\fR \*(-- 64-bit float
 .IP "\(bu" 4
-\&\fBU\fR \*(-- unsigned 16\-bit int
+\&\fBU\fR \*(-- unsigned 16-bit int
 .IP "\(bu" 4
-\&\fBV\fR \*(-- unsigned 32\-bit int
+\&\fBV\fR \*(-- unsigned 32-bit int
 .PP
 An optional integer value \fBn\fR can be prefixed to the type to indicate
 that the element is an array of n values. For example:
@@ -270,7 +270,7 @@ that the element is an array of n values. For example:
 \&  foo.fits[EVENTS(x:I,y:I,status:4J)]
 .Ve
 .PP
-defines x and y as 16\-bit ints and status as an array of 4 32\-bit ints.
+defines x and y as 16-bit ints and status as an array of 4 32-bit ints.
 .PP
 Furthermore, image dimensions can be attached to the event specification
 in order to tell Funtools how to bin the events into an image. They
@@ -376,17 +376,17 @@ where array-spec is of the form:
 .PP
 and where [type] is:
 .IP "\(bu" 4
-b   (8\-bit unsigned char)
+b   (8-bit unsigned char)
 .IP "\(bu" 4
-s   (16\-bit short int)
+s   (16-bit short int)
 .IP "\(bu" 4
-u   (16\-bit unsigned short int)
+u   (16-bit unsigned short int)
 .IP "\(bu" 4
-i   (32\-bit int)
+i   (32-bit int)
 .IP "\(bu" 4
-r,f (32\-bit float)
+r,f (32-bit float)
 .IP "\(bu" 4
-d   (64\-bit float)
+d   (64-bit float)
 .PP
 The dim1 specification is required, but dim2 is optional and defaults
 to dim1.  The skip specification is optional and defaults to 0.  The
@@ -799,4 +799,4 @@ in a filter, enclose the file specification in quotes:
 .Ve
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funfilters.7
+++ b/man/man7/funfilters.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funfilters n"
-.TH funfilters n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funfilters 7"
+.TH funfilters 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunfilters: Filtering Rows in a Table\fR
+Funfilters \- Filtering Rows in a Table
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document contains a summary of the user interface for 
@@ -461,4 +461,4 @@ notation (use decimal, hex, or octal instead). Please contact us if
 this is a problem.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funidx.7
+++ b/man/man7/funidx.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funidx n"
-.TH funidx n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funidx 7"
+.TH funidx 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunidx: Using Indexes to Filter Rows in a Table\fR
+Funidx \- Using Indexes to Filter Rows in a Table
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document contains a summary of the user interface for 
@@ -324,4 +324,4 @@ event files. It does not work with text files. This restriction might be
 removed in a future release.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funregions.7
+++ b/man/man7/funregions.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funregions n"
-.TH funregions n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funregions 7"
+.TH funregions 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBRegions: Spatial Region Filtering\fR
+FunRegions \- Spatial Region Filtering
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document contains a summary of the user interface for spatial
@@ -483,8 +483,8 @@ which is equivalent to:
 .PP
 The latter syntax only applies the pi test to the first region.
 .PP
-For image-style filtering, the \fB@filename\fR can specify an 8\-bit
-or 16\-bit \s-1FITS\s0 image. In this case, the pixel values in the mask image
+For image-style filtering, the \fB@filename\fR can specify an 8-bit
+or 16-bit \s-1FITS\s0 image. In this case, the pixel values in the mask image
 are used as the region mask. The valid pixels in the mask must have
 positive values.  Zero values are excluded from the mask and negative
 values are not allowed.  Moreover, the region id value is taken as
@@ -675,4 +675,4 @@ Region Coordinates, and
 Region Boundaries.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funtext.7
+++ b/man/man7/funtext.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funtext n"
-.TH funtext n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funtext 7"
+.TH funtext 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFuntext: Support for Column\-based Text Files\fR
+Funtext \- Support for Column\-based Text Files
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document contains a summary of the options for processing column-based
@@ -145,7 +145,7 @@ using the same syntax as \s-1FITS\s0 binary tables:
 .PP
 .Vb 3
 \&  fundisp foo.txt'[cir 512 512 .1]'
-\&  fundisp -T foo.txt > foo.rdb
+\&  fundisp \-T foo.txt > foo.rdb
 \&  funtable foo.txt'[pha=1:10,cir 512 512 10]' foo.fits
 .Ve
 .PP
@@ -710,4 +710,4 @@ The issue of data type transitions (which to allow and which to disallow)
 is still under discussion.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/funtools.7
+++ b/man/man7/funtools.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funtools n"
-.TH funtools n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funtools 7"
+.TH funtools 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFuntools: FITS Users Need Tools\fR
+Funtools \- FITS Users Need Tools
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document is the Table of Contents for Funtools.
@@ -208,7 +208,7 @@ Funtools \s-1ASCII\s0 output
 [\fIfuntbl\fR\|(1)]
 .IP "\(bu" 4
 funtools and ds9 image display
-[funds9(n)]
+[funds9(7)]
 .RE
 .RS 4
 .RE
@@ -302,7 +302,7 @@ imblank: blank out image values below a threshold
 .RE
 .IP "\(bu" 4
 Funtools Data Files
-[funfiles(n)]
+[funfiles(7)]
 .RS 4
 .IP "\(bu" 4
 Supported Data Formats
@@ -334,35 +334,35 @@ Funtools Data Filtering
 .RS 4
 .IP "\(bu" 4
 Table Filtering
-[funfilters(n)]
+[funfilters(7)]
 .IP "\(bu" 4
 Fast Table Filtering using Indexes
-[funidx(n)]
+[funidx(7)]
 .IP "\(bu" 4
 Spatial Region Filtering
-[funregions(n)]
+[funregions(7)]
 .RS 4
 .IP "\(bu" 4
 Region Geometry
-[reggeometry(n)]
+[reggeometry(7)]
 .IP "\(bu" 4
 Region Algebra
-[regalgebra(n)]
+[regalgebra(7)]
 .IP "\(bu" 4
 Region Coordinates
-[regcoords(n)]
+[regcoords(7)]
 .IP "\(bu" 4
 Region Boundaries
-[regbounds(n)]
+[regbounds(7)]
 .IP "\(bu" 4
 Differences Between Funtools and \s-1IRAF\s0 Regions
-[regdiff(n)]
+[regdiff(7)]
 .RE
 .RS 4
 .RE
 .IP "\(bu" 4
 Combining Table and Region Filters
-[funcombine(n)]
+[funcombine(7)]
 .RE
 .RS 4
 .RE
@@ -371,7 +371,7 @@ Miscellaneous
 .RS 4
 .IP "\(bu" 4
 Funtools Environment Variables
-[funenv(n)]
+[funenv(7)]
 .IP "\(bu" 4
 Funtools ChangeLog
 .RE

--- a/man/man7/funview.7
+++ b/man/man7/funview.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funview n"
-.TH funview n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "funview 7"
+.TH funview 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunview: Database View Support for Tables\fR
+Funview \- Database View Support for Tables
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document contains a summary of the options for utilizing
@@ -238,7 +238,7 @@ parameters) is processed as the input file to fundisp. Using the
 example database, above, this is equivalent to:
 .PP
 .Vb 1
-\&  fundisp  -f "I=%4d" ${HOME}/data/snr.ev'[cir 512 512 .1]'  "x y pi pha"
+\&  fundisp  \-f "I=%4d" ${HOME}/data/snr.ev'[cir 512 512 .1]'  "x y pi pha"
 .Ve
 .PP
 That is, the format is used with fundisp's \-f (format) switch, while the
@@ -324,7 +324,7 @@ simple template match is attempted against the \fBfile\fR columns.
 5. If no match is found, then the filename (minus the \*(L"v:\*(R" prefix) is 
 returned.
 .PP
-\&\fBMore on View Matching Rules: Single vs. Multiple Matches \fR
+More on View Matching Rules -  Single vs. Multiple Matches 
 .PP
 The matching rules described above stop after the first match,
 regardless of whether that match provides values for all three
@@ -371,7 +371,7 @@ against the x1 file name:
 Note once again that order is important: missing values are taken in the
 order in which the template matches are processed.
 .PP
-\&\fBView Lists: Applying a View to Any File\fR
+View Lists -  Applying a View to Any File
 .PP
 It is possible to apply a named View, or even several Views, to any
 data file by appending a \fBviewlist\fR immediately after the standard \*(L"v:\*(R"
@@ -459,7 +459,7 @@ associated parameters, be processed as the input file to fundisp in
 this way:
 .PP
 .Vb 1
-\&  fundisp  -f "I=%4d" ${HOME}/data/snr.ev'[cir 512 512 .1]'  "x y pi pha"
+\&  fundisp  \-f "I=%4d" ${HOME}/data/snr.ev'[cir 512 512 .1]'  "x y pi pha"
 .Ve
 .PP
 To override one or more of these values, simply specify a new value
@@ -476,7 +476,7 @@ examples are:
 .PP
 .Vb 2
 \&  fundisp v:x3 "x y dx dy"    # activate a different set of columns
-\&  fundisp -f "I=%3d" v:x3     # use a different format statement
+\&  fundisp \-f "I=%3d" v:x3     # use a different format statement
 .Ve
 .PP
 Note that extension names, extension index values, and other

--- a/man/man7/regalgebra.7
+++ b/man/man7/regalgebra.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "regalgebra n"
-.TH regalgebra n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "regalgebra 7"
+.TH regalgebra 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBRegAlgebra: Boolean Algebra on Spatial Regions\fR
+RegAlgebra \- Boolean Algebra on Spatial Regions
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document describes the boolean arithmetic defined for 
@@ -368,8 +368,8 @@ affect other regions with which it overlaps:
 .Vb 5
 \&        CIRCLE(1,8,1)
 \&        CIRCLE(8,8,7)
-\&        -PIE(8,8,60,120)
-\&        -PIE(8,8,240,300)
+\&        \-PIE(8,8,60,120)
+\&        \-PIE(8,8,240,300)
 \&        CIRCLE(15,8,2)
 .Ve
 .PP
@@ -397,4 +397,4 @@ The two smaller circles are entirely contained within the two exclude
 \&\fB\s-1PIE\s0\fR slices and therefore are excluded from the region.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/regbounds.7
+++ b/man/man7/regbounds.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "regbounds n"
-.TH regbounds n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "regbounds 7"
+.TH regbounds 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBRegBounds: Region Boundaries\fR
+RegBounds \- Region Boundaries
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 Describes how spatial region boundaries are handled.
@@ -154,7 +154,7 @@ separately.
 With this in mind, the rules for determining whether a boundary image
 pixel or table row are assigned to a region are defined below.
 .PP
-\&\fBImage boundaries : radially-symmetric shapes (circle, annuli, ellipse)\fR
+\&\fBImage boundaries  -  radially-symmetric shapes (circle, annuli, ellipse)\fR
 .PP
 For image filtering, pixels whose center is inside the boundary are
 included.  This also applies non-radially-symmetric shapes.  When a
@@ -302,4 +302,4 @@ that funcnts would give the exact same results regardless of whether
 a table or a derived non-blocked binned image is used.]
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/regcoords.7
+++ b/man/man7/regcoords.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "regcoords n"
-.TH regcoords n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "regcoords 7"
+.TH regcoords 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBRegCoords: Spatial Region Coordinates\fR
+RegCoords \- Spatial Region Coordinates
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document describes the specification of coordinate systems, and the 
@@ -278,7 +278,7 @@ An example of using sky coordinate systems follows:
 .PP
 .Vb 4
 \&  global coordsys B1950
-\&  -box 175.54d 20.01156d 10' 10'
+\&  \-box 175.54d 20.01156d 10' 10'
 \&  local coordsys J2000
 \&  pie 179.57d 22.4d 0 360 n=4 && annulus 179.57d 22.4d 3' 24' n=5
 .Ve
@@ -342,4 +342,4 @@ can be generated safely by asking ds9 to save/display regions in
 pixels using the \s-1PHYSICAL\s0 coordsys.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/regdiff.7
+++ b/man/man7/regdiff.7
@@ -128,121 +128,54 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "funcombine n"
-.TH funcombine n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "regdiff 7"
+.TH regdiff 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBFunCombine: Combining Region and Table Filters\fR
+RegDiff \- Differences Between Funtools and IRAF Regions
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
-This document discusses the conventions for combining region and table
-filters, especially with regards to the comma operator.
+Describes the differences between Funtools/ds9 regions and the old \s-1IRAF/PROS\s0
+regions.
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
-\&\fBComma Conventions\fR
-.PP
-Filter specifications consist of a series of boolean expressions,
-separated by commas. These expressions can be table filters,
-spatial region filters, or combinations thereof. Unfortunately,
-common usage requires that the comma operator must act differently
-in different situations. Therefore, while its use is intuitive in
-most cases, commas can be a source of confusion.
-.PP
-According to long-standing usage in \s-1IRAF\s0, when a comma separates two
-table filters, it takes on the meaning of a boolean \fBand\fR. Thus:
-.PP
-.Vb 1
-\&  foo.fits[pha==1,pi==2]
-.Ve
-.PP
-is equivalent to:
-.PP
-.Vb 1
-\&  foo.fits[pha==1 && pi==2]
-.Ve
-.PP
-When a comma separates two spatial region filters, however, it has
-traditionally taken on the meaning of a boolean \fBor\fR. Thus:
-.PP
-.Vb 1
-\&  foo.fits[circle(10,10,3),ellipse(20,20,8,5)]
-.Ve
-.PP
-is equivalent to:
-.PP
-.Vb 1
-\&  foo.fits[circle(10,10,3) || ellipse(20,20,8,5)]
-.Ve
-.PP
-(except that in the former case, each region is given a unique id
-in programs such as funcnts).
-.PP
-Region and table filters can be combined:
-.PP
-.Vb 1
-\&  foo.fits[circle(10,10,3),pi=1:5]
-.Ve
-.PP
-or even:
-.PP
-.Vb 1
-\&  foo.fits[pha==1&&circle(10,10,3),pi==2&&ellipse(20,20,8,5)]
-.Ve
-.PP
-In these cases, it is not obvious whether the command should utilize an
-\&\fBor\fR or \fBand\fR operator. We therefore arbitrarily chose to
-implement the following rule:
+We have tried to make Funtools regions compatible with their
+predecessor, \s-1IRAF/PROS\s0 regions. For simple regions and simple boolean
+algebra between regions, there should be no difference between the two
+implementations.  The following is a list of differences and
+incompatibilities between the two:
 .IP "\(bu" 4
-if both expressions contain a region, the operator used is \fBor\fR.
+If a pixel is covered by two different regions expressions,
+Funtools assigns the mask value of the \fBfirst\fR region that
+contains that pixel.  That is, successive regions \fBdo not\fR
+overwrite previous regions in the mask, as was the case with the
+original \s-1PROS\s0 regions.  This means that one must define overlapping
+regions in the reverse order in which they were defined in \s-1PROS\s0.  If
+region N is fully contained within region M, then N should be defined
+\&\fBbefore\fR M, or else it will be \*(L"covered up\*(R" by the latter. This
+change is necessitated by the use of optimized filter compilation, i.e.,
+Funtools only tests individual regions until a proper match is made.
 .IP "\(bu" 4
-if one (or both) expression(s) does not contain a region, the operator
-used is \fBand\fR.
-.PP
-This rule handles the cases of pure regions and pure column filters properly.
-It unambiguously assigns the boolean \fBand\fR to all mixed cases. Thus:
-.PP
+The \fB\s-1PANDA\s0\fR region has replaced the old \s-1PROS\s0 syntax in which
+a \fB\s-1PIE\s0\fR accelerator was combined with an \fB\s-1ANNULUS\s0\fR accelerator
+using \fB\s-1AND\s0\fR. That is,
+.Sp
 .Vb 1
-\&  foo.fits[circle(10,10,3),pi=1:5]
+\&  ANNULUS(20,20,0,15,n=4) & PIE(20,20,0,360,n=3)
 .Ve
-.PP
-and
-.PP
+.Sp
+has been replaced by:
+.Sp
 .Vb 1
-\&  foo.fits[pi=1:5,circle(10,10,3)]
+\&  PANDA(20,20,0,360,3,0,15,4)
 .Ve
-.PP
-both are equivalent to:
-.PP
-.Vb 1
-\&  foo.fits[circle(10,10,3) && pi=1:5]
-.Ve
-.PP
-[\s-1NB:\s0 This arbitrary rule \fBreplaces the previous arbitrary rule\fR
-(pre\-funtools 1.2.3) which stated:
+.Sp
+The \s-1PROS\s0 syntax was inconsistent with the meaning of the \fB\s-1AND\s0\fR operator.
 .IP "\(bu" 4
-if the 2nd expression contains a region, the operator used is \fBor\fR.
-.IP "\(bu" 4
-if the 2nd expression does not contain a region, the operator
-used is \fBand\fR.
-.PP
-In that scenario, the \fBor\fR operator was implied by:
-.PP
-.Vb 1
-\&  pha==4,circle 5 5 1
-.Ve
-.PP
-while the \fBand\fR operator was implied by
-.PP
-.Vb 1
-\&  circle 5 5 1,pha==4
-.Ve
-.PP
-Experience showed that this non-commutative treatment of the comma
-operator was confusing and led to unexpected results.]
-.PP
-The comma rule must be considered provisional: comments and complaints
-are welcome to help clarify the matter. Better still, we recommend
-that the comma operator be avoided in such cases in favor of an
-explicit boolean operator.
+The meaning of pure numbers (i.e., without format specifiers) in 
+regions has been clarified, as has the syntax for specifying coordinate
+systems. See the general discussion on
+Spatial Region Filtering
+for more information.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages

--- a/man/man7/reggeometry.7
+++ b/man/man7/reggeometry.7
@@ -128,10 +128,10 @@
 .rm #[ #] #H #V #F C
 .\" ========================================================================
 .\"
-.IX Title "reggeometry n"
-.TH reggeometry n "April 14, 2011" "version 1.4.5" "SAORD Documentation"
+.IX Title "reggeometry 7"
+.TH reggeometry 7 "April 14, 2011" "version 1.4.5" "SAORD Documentation"
 .SH "NAME"
-\&\fBRegGeometry: Geometric Shapes in Spatial Region Filtering\fR
+RegGeometry \- Geometric Shapes in Spatial Region Filtering
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 This document describes the geometry of regions available for spatial
@@ -1268,4 +1268,4 @@ Note that you must supply an image of the appropriate size \*(-- in this case,
 a \s-1FITS\s0 image of dimension 40x40 is used.]
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-See funtools(n) for a list of Funtools help pages
+See funtools(7) for a list of Funtools help pages


### PR DESCRIPTION
- Use minus signs `\-` instead of hyphens `-`
- rename section "n" to section "7" to match the [Filesystem hierarchy standard](http://www.pathname.com/fhs/pub/fhs-2.3.html#USRSHAREMANMANUALPAGES)
- format the "name" field as `name \- description`
