### PR TITLE
add missing object file to makefile

### DIFF
--- a/wcs/Makefile.in
+++ b/wcs/Makefile.in
@@ -93,7 +93,7 @@ SRCS =  wcsinit.c wcs.c wcscon.c fitsfile.c imhfile.c fileutil.c \
         wcslib.c lin.c cel.c proj.c sph.c wcstrig.c dateutil.c distort.c \
 	zpxpos.c
 
-OBJS =  wcsinit.o wcs.o wcscon.o fitsfile.o imhfile.o \
+OBJS =  wcsinit.o wcs.o wcscon.o fitsfile.o imhfile.o fileutil.o \
 	hget.o hput.o iget.o imio.o worldpos.o platepos.o \
 	tnxpos.o zpxpos.o dsspos.o poly.o \
         wcslib.o lin.o cel.o proj.o sph.o wcstrig.o dateutil.o distort.o


### PR DESCRIPTION
wcs/fileutil.c was not being compiled, even though wcs/fitsfile.c
(which is compiled) depended upon symbols in it. This
resulted in undefined symbols in the libraries, which caused a link
problem when linking against the shared library, e.g.:

/.../libfuntools.so: undefined reference to `getfilesize'